### PR TITLE
Make the TSS2_ABI_CURRENT_VERSION an actual value, not a macro.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ SET(SRCS src/tss2_tcti_socket.c
          src/tss2_sys_commit.c
          src/tss2_sys_sign.c
          src/internal/cmdauths.c
+         src/internal/constants.c
          src/internal/execute.c
          src/internal/marshal.c
          src/internal/sys_context_common.c

--- a/include/tss2/tss2_common.h
+++ b/include/tss2/tss2_common.h
@@ -35,10 +35,7 @@ typedef struct {
     uint32_t tssVersion;      
 } TSS2_ABI_VERSION;
 
-#define TSS2_ABI_CURRENT_VERSION {.tssCreator = 0x1,    \
-                                  .tssFamily = 0x1,     \
-                                  .tssLevel = 0x1,        \
-                                  .tssVersion = 0x1 }
+extern const TSS2_ABI_VERSION TSS2_ABI_CURRENT_VERSION;
 
 typedef uint32_t TSS2_RC;
 

--- a/src/internal/constants.c
+++ b/src/internal/constants.c
@@ -1,0 +1,24 @@
+/******************************************************************************
+ *
+ * Copyright 2017 Xaptum, Inc.
+ * 
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include <tss2/tss2_common.h>
+
+const TSS2_ABI_VERSION TSS2_ABI_CURRENT_VERSION = {.tssCreator = 0x1,
+                                                   .tssFamily = 0x1,
+                                                   .tssLevel = 0x1,
+                                                   .tssVersion = 0x1};

--- a/src/tss2_sys_context_allocation.c
+++ b/src/tss2_sys_context_allocation.c
@@ -47,11 +47,10 @@ Tss2_Sys_Initialize(TSS2_SYS_CONTEXT *sysContext,
         return TSS2_SYS_RC_BAD_TCTI_STRUCTURE;
     }
 
-    TSS2_ABI_VERSION current = TSS2_ABI_CURRENT_VERSION;
-    if (abiVersion->tssCreator != current.tssCreator ||
-            abiVersion->tssFamily != current.tssFamily ||
-            abiVersion->tssLevel != current.tssLevel ||
-            abiVersion->tssVersion != current.tssVersion) {
+    if (abiVersion->tssCreator != TSS2_ABI_CURRENT_VERSION.tssCreator ||
+            abiVersion->tssFamily != TSS2_ABI_CURRENT_VERSION.tssFamily ||
+            abiVersion->tssLevel != TSS2_ABI_CURRENT_VERSION.tssLevel ||
+            abiVersion->tssVersion != TSS2_ABI_CURRENT_VERSION.tssVersion) {
         return TSS2_SYS_RC_ABI_MISMATCH;
     }
 


### PR DESCRIPTION
This facilitates the Python wrapper.