### PR TITLE
Reorganize cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,32 +18,32 @@ project(xaptum-tpm
         LANGUAGES C
         VERSION "0.3.0")
 
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Wall -Wextra -Wno-missing-field-initializers -std=c99 -D_POSIX_C_SOURCE=200112L")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Wall -Wextra -Wno-missing-field-initializers -std=c99 -D_POSIX_C_SOURCE=200112L")
 
-SET(CMAKE_C_FLAGS_RELWITHSANITIZE "${CMAKE_C_FLAGS_RELWITHSANITIZE} -O2 -g -fsanitize=address,undefined -fsanitize=unsigned-integer-overflow")
+set(CMAKE_C_FLAGS_RELWITHSANITIZE "${CMAKE_C_FLAGS_RELWITHSANITIZE} -O2 -g -fsanitize=address,undefined -fsanitize=unsigned-integer-overflow")
 
-SET(SRCS src/tss2_tcti_socket.c
-         src/tss2_sys_context_allocation.c
-         src/tss2_sys_createprimary.c
-         src/tss2_sys_commit.c
-         src/tss2_sys_hierarchychangeauth.c
-         src/tss2_sys_nv.c
-         src/tss2_sys_sign.c
-         src/internal/cmdauths.c
-         src/internal/constants.c
-         src/internal/execute.c
-         src/internal/marshal.c
-         src/internal/sys_context_common.c
-         src/internal/command_utils.c)
+set(XAPTUM_TPM_SRCS
+    src/tss2_tcti_socket.c
+    src/tss2_sys_context_allocation.c
+    src/tss2_sys_createprimary.c
+    src/tss2_sys_commit.c
+    src/tss2_sys_hierarchychangeauth.c
+    src/tss2_sys_nv.c
+    src/tss2_sys_sign.c
+    src/internal/cmdauths.c
+    src/internal/constants.c
+    src/internal/execute.c
+    src/internal/marshal.c
+    src/internal/sys_context_common.c
+    src/internal/command_utils.c
+)
 
-add_library(xaptumtpm
-        OBJECT
-        ${SRCS}
-        )
-set_property(TARGET xaptumtpm PROPERTY POSITION_INDEPENDENT_CODE 1)
-target_include_directories(xaptumtpm PUBLIC ./include/)
-add_library(xaptumtpm-shared SHARED $<TARGET_OBJECTS:xaptumtpm>)
-add_library(xaptumtpm-static STATIC $<TARGET_OBJECTS:xaptumtpm>)
+add_library(xaptum_tpm-obj OBJECT ${XAPTUM_TPM_SRCS})
+set_property(TARGET xaptum_tpm-obj PROPERTY POSITION_INDEPENDENT_CODE 1)
+target_include_directories(xaptum_tpm-obj PUBLIC ./include/)
+
+add_library(xaptum_tpm-shared SHARED $<TARGET_OBJECTS:xaptum_tpm-obj>)
+add_library(xaptum_tpm-static STATIC $<TARGET_OBJECTS:xaptum_tpm-obj>)
 
 enable_testing()
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,16 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Wall -Wextra -Wno-missing-field-ini
 
 set(CMAKE_C_FLAGS_RELWITHSANITIZE "${CMAKE_C_FLAGS_RELWITHSANITIZE} -O2 -g -fsanitize=address,undefined -fsanitize=unsigned-integer-overflow")
 
+option(BUILD_SHARED_LIBS "Build as a shared library" ON)
+option(BUILD_STATIC_LIBS "Build as a static library" OFF)
+
+# If not building as a shared library, force build as a static.  This
+# is to match the CMake default semantics of using
+# BUILD_SHARED_LIBS = OFF to indicate a static build.
+if(NOT DEFINED BUILD_SHARED_LIBS OR NOT  "${BUILD_SHARED_LIBS}")
+  set(BUILD_STATIC_LIBS ON CACHE BOOL "Build as a static library" FORCE)
+endif()
+
 set(XAPTUM_TPM_SRCS
     src/tss2_tcti_socket.c
     src/tss2_sys_context_allocation.c
@@ -38,12 +48,26 @@ set(XAPTUM_TPM_SRCS
     src/internal/command_utils.c
 )
 
-add_library(xaptum_tpm-obj OBJECT ${XAPTUM_TPM_SRCS})
-set_target_properties(xaptum_tpm-obj PROPERTIES POSITION_INDEPENDENT_CODE 1)
-target_include_directories(xaptum_tpm-obj PUBLIC include)
+if(BUILD_SHARED_LIBS)
+  add_library(xaptum_tpm SHARED ${XAPTUM_TPM_SRCS})
 
-add_library(xaptum_tpm-shared SHARED $<TARGET_OBJECTS:xaptum_tpm-obj>)
-add_library(xaptum_tpm-static STATIC $<TARGET_OBJECTS:xaptum_tpm-obj>)
+  set_target_properties(xaptum_tpm PROPERTIES
+    POSITION_INDEPENDENT_CODE 1
+  )
+
+  target_include_directories(xaptum_tpm PUBLIC include)
+endif()
+
+if(BUILD_STATIC_LIBS)
+  add_library(xaptum_tpm_static STATIC ${XAPTUM_TPM_SRCS})
+
+  set_target_properties(xaptum_tpm_static PROPERTIES
+    OUTPUT_NAME "xaptum_tpm${STATIC_SUFFIX}"
+    POSITION_INDEPENDENT_CODE 1
+  )
+
+  target_include_directories(xaptum_tpm_static PUBLIC include)
+endif()
 
 enable_testing()
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(XAPTUM_TPM_SRCS
 )
 
 add_library(xaptum_tpm-obj OBJECT ${XAPTUM_TPM_SRCS})
-set_property(TARGET xaptum_tpm-obj PROPERTY POSITION_INDEPENDENT_CODE 1)
+set_target_properties(xaptum_tpm-obj PROPERTIES POSITION_INDEPENDENT_CODE 1)
 target_include_directories(xaptum_tpm-obj PUBLIC ./include/)
 
 add_library(xaptum_tpm-shared SHARED $<TARGET_OBJECTS:xaptum_tpm-obj>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ project(xaptum-tpm
         LANGUAGES C
         VERSION "0.3.0")
 
+include(GNUInstallDirs)
 include(CTest)
       
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Wall -Wextra -Wno-missing-field-initializers -std=c99 -D_POSIX_C_SOURCE=200112L")
@@ -52,6 +53,12 @@ set(XAPTUM_TPM_SRCS
 if(BUILD_SHARED_LIBS)
   add_library(xaptum_tpm SHARED ${XAPTUM_TPM_SRCS})
   target_include_directories(xaptum_tpm PUBLIC include)
+
+  install(TARGETS xaptum_tpm
+          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
 endif()
 
 if(BUILD_STATIC_LIBS)
@@ -62,6 +69,14 @@ if(BUILD_STATIC_LIBS)
   )
 
   target_include_directories(xaptum_tpm_static PUBLIC include)
+
+  install(TARGETS xaptum_tpm_static
+          RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+          LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+          ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  )
 endif()
+
+install(DIRECTORY include/tss2 DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ if(NOT DEFINED BUILD_SHARED_LIBS OR NOT  "${BUILD_SHARED_LIBS}")
   set(BUILD_STATIC_LIBS ON CACHE BOOL "Build as a static library" FORCE)
 endif()
 
+set(XAPTUM_TPM_VERSION ${PROJECT_VERSION})
+set(XAPTUM_TPM_SOVERSION ${PROJECT_VERSION_MAJOR})
+
 set(XAPTUM_TPM_SRCS
     src/tss2_tcti_socket.c
     src/tss2_sys_context_allocation.c
@@ -52,6 +55,12 @@ set(XAPTUM_TPM_SRCS
 
 if(BUILD_SHARED_LIBS)
   add_library(xaptum_tpm SHARED ${XAPTUM_TPM_SRCS})
+
+  set_target_properties(xaptum_tpm PROPERTIES
+    VERSION "${XAPTUM_TPM_VERSION}"
+    SOVERSION "${XAPTUM_TPM_SOVERSION}"
+  )
+  
   target_include_directories(xaptum_tpm PUBLIC include)
 
   install(TARGETS xaptum_tpm
@@ -66,6 +75,8 @@ if(BUILD_STATIC_LIBS)
 
   set_target_properties(xaptum_tpm_static PROPERTIES
     OUTPUT_NAME "xaptum_tpm${STATIC_SUFFIX}"
+    VERSION "${XAPTUM_TPM_VERSION}"
+    SOVERSION "${XAPTUM_TPM_SOVERSION}"
   )
 
   target_include_directories(xaptum_tpm_static PUBLIC include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-project(xaptum-tpm
+project(xaptum_tpm
         LANGUAGES C
         VERSION "0.3.0")
 
@@ -61,9 +61,13 @@ if(BUILD_SHARED_LIBS)
     SOVERSION "${XAPTUM_TPM_SOVERSION}"
   )
   
-  target_include_directories(xaptum_tpm PUBLIC include)
+  target_include_directories(xaptum_tpm PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
 
   install(TARGETS xaptum_tpm
+          EXPORT ${CMAKE_PROJECT_NAME}Targets
           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -79,9 +83,13 @@ if(BUILD_STATIC_LIBS)
     SOVERSION "${XAPTUM_TPM_SOVERSION}"
   )
 
-  target_include_directories(xaptum_tpm_static PUBLIC include)
+  target_include_directories(xaptum_tpm_static PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
 
   install(TARGETS xaptum_tpm_static
+          EXPORT ${CMAKE_PROJECT_NAME}Targets
           RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
           LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
           ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
@@ -92,5 +100,10 @@ install(DIRECTORY include/tss2 DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 configure_file(xaptum_tpm.pc.in xaptum_tpm.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/xaptum_tpm.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+install(EXPORT ${CMAKE_PROJECT_NAME}Targets
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
+        FILE        ${CMAKE_PROJECT_NAME}Config.cmake
+)
 
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,4 +90,7 @@ endif()
 
 install(DIRECTORY include/tss2 DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
+configure_file(xaptum_tpm.pc.in xaptum_tpm.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/xaptum_tpm.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,11 +51,6 @@ set(XAPTUM_TPM_SRCS
 
 if(BUILD_SHARED_LIBS)
   add_library(xaptum_tpm SHARED ${XAPTUM_TPM_SRCS})
-
-  set_target_properties(xaptum_tpm PROPERTIES
-    POSITION_INDEPENDENT_CODE 1
-  )
-
   target_include_directories(xaptum_tpm PUBLIC include)
 endif()
 
@@ -64,7 +59,6 @@ if(BUILD_STATIC_LIBS)
 
   set_target_properties(xaptum_tpm_static PROPERTIES
     OUTPUT_NAME "xaptum_tpm${STATIC_SUFFIX}"
-    POSITION_INDEPENDENT_CODE 1
   )
 
   target_include_directories(xaptum_tpm_static PUBLIC include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,9 @@ project(xaptum-tpm
         LANGUAGES C
         VERSION "0.3.0")
 
+include(CTest)
+      
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Wall -Wextra -Wno-missing-field-initializers -std=c99 -D_POSIX_C_SOURCE=200112L")
-
 set(CMAKE_C_FLAGS_RELWITHSANITIZE "${CMAKE_C_FLAGS_RELWITHSANITIZE} -O2 -g -fsanitize=address,undefined -fsanitize=unsigned-integer-overflow")
 
 option(BUILD_SHARED_LIBS "Build as a shared library" ON)
@@ -69,5 +70,4 @@ if(BUILD_STATIC_LIBS)
   target_include_directories(xaptum_tpm_static PUBLIC include)
 endif()
 
-enable_testing()
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-project(xaptum_tpm
+project(xaptum-tpm
         LANGUAGES C
         VERSION "0.3.0")
 
@@ -54,19 +54,19 @@ set(XAPTUM_TPM_SRCS
 )
 
 if(BUILD_SHARED_LIBS)
-  add_library(xaptum_tpm SHARED ${XAPTUM_TPM_SRCS})
+  add_library(xaptum-tpm SHARED ${XAPTUM_TPM_SRCS})
 
-  set_target_properties(xaptum_tpm PROPERTIES
+  set_target_properties(xaptum-tpm PROPERTIES
     VERSION "${XAPTUM_TPM_VERSION}"
     SOVERSION "${XAPTUM_TPM_SOVERSION}"
   )
   
-  target_include_directories(xaptum_tpm PUBLIC
+  target_include_directories(xaptum-tpm PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   )
 
-  install(TARGETS xaptum_tpm
+  install(TARGETS xaptum-tpm
           EXPORT ${CMAKE_PROJECT_NAME}Targets
           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -75,20 +75,20 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 if(BUILD_STATIC_LIBS)
-  add_library(xaptum_tpm_static STATIC ${XAPTUM_TPM_SRCS})
+  add_library(xaptum-tpm_static STATIC ${XAPTUM_TPM_SRCS})
 
-  set_target_properties(xaptum_tpm_static PROPERTIES
-    OUTPUT_NAME "xaptum_tpm${STATIC_SUFFIX}"
+  set_target_properties(xaptum-tpm_static PROPERTIES
+    OUTPUT_NAME "xaptum-tpm${STATIC_SUFFIX}"
     VERSION "${XAPTUM_TPM_VERSION}"
     SOVERSION "${XAPTUM_TPM_SOVERSION}"
   )
 
-  target_include_directories(xaptum_tpm_static PUBLIC
+  target_include_directories(xaptum-tpm_static PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   )
 
-  install(TARGETS xaptum_tpm_static
+  install(TARGETS xaptum-tpm_static
           EXPORT ${CMAKE_PROJECT_NAME}Targets
           RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
           LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
@@ -98,8 +98,8 @@ endif()
 
 install(DIRECTORY include/tss2 DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
-configure_file(xaptum_tpm.pc.in xaptum_tpm.pc @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/xaptum_tpm.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+configure_file(xaptum-tpm.pc.in xaptum-tpm.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/xaptum-tpm.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 install(EXPORT ${CMAKE_PROJECT_NAME}Targets
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(XAPTUM_TPM_SRCS
 
 add_library(xaptum_tpm-obj OBJECT ${XAPTUM_TPM_SRCS})
 set_target_properties(xaptum_tpm-obj PROPERTIES POSITION_INDEPENDENT_CODE 1)
-target_include_directories(xaptum_tpm-obj PUBLIC ./include/)
+target_include_directories(xaptum_tpm-obj PUBLIC include)
 
 add_library(xaptum_tpm-shared SHARED $<TARGET_OBJECTS:xaptum_tpm-obj>)
 add_library(xaptum_tpm-static STATIC $<TARGET_OBJECTS:xaptum_tpm-obj>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,8 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(xaptum-tpm
         LANGUAGES C
-        VERSION "0.3.0")
+        VERSION "0.3.0"
+)
 
 include(GNUInstallDirs)
 include(CTest)
@@ -53,6 +54,9 @@ set(XAPTUM_TPM_SRCS
     src/internal/command_utils.c
 )
 
+################################################################################
+# Shared Libary
+################################################################################
 if(BUILD_SHARED_LIBS)
   add_library(xaptum-tpm SHARED ${XAPTUM_TPM_SRCS})
 
@@ -74,6 +78,9 @@ if(BUILD_SHARED_LIBS)
   )
 endif()
 
+################################################################################
+# Static Libary
+################################################################################
 if(BUILD_STATIC_LIBS)
   add_library(xaptum-tpm_static STATIC ${XAPTUM_TPM_SRCS})
 
@@ -96,11 +103,20 @@ if(BUILD_STATIC_LIBS)
   )
 endif()
 
+################################################################################
+# Headers
+################################################################################
 install(DIRECTORY include/tss2 DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
+################################################################################
+# pkgconfig
+################################################################################
 configure_file(xaptum-tpm.pc.in xaptum-tpm.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/xaptum-tpm.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
+################################################################################
+# CMake export
+################################################################################
 install(EXPORT ${CMAKE_PROJECT_NAME}Targets
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
         FILE        ${CMAKE_PROJECT_NAME}Config.cmake

--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ cmake --build .
 In addition to the standard CMake options the following configuration
 options and variables are supported.
 
+### Static vs Shared Libary
 If `BUILD_SHARED_LIBS` is set, the shared library is built. If
 `BUILD_STATIC_LIBS` is set, the static library is built. If both are
 set, both libraries will be built.  If neither is set, the static
 library will be built.
 
+### Static Library Name
 `STATIC_SUFFIX`, if defined, will be appended to the static library
 name.  For example,
 
@@ -44,6 +46,10 @@ cmake --build .
 ```
 
 will create a static library named `libxaptum_tpm_static.a`.
+
+### Disable Building of Tests
+Set the standard CMake variable `BUILD_TESTING` to `OFF` to disable
+the building of tests.  The default value is `ON`.
 
 ## Running the tests
 The tests assume that a TPM2.0 simulator (for instance, [IBM's simulator](https://sourceforge.net/projects/ibmswtpm2/))

--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ default is `OFF` for static libraries and `ON` for shared libraries.
 Set the standard CMake variable `BUILD_TESTING` to `OFF` to disable
 the building of tests.  The default value is `ON`.
 
+## Installation
+
+CMake creates a target for installation.
+
+```bash
+cd build
+cmake --build . --target install
+```
+
+Set the `CMAKE_INSTALL_PREFIX` variable when configuring the build to
+modify the installation location.
+
 ## Running the tests
 The tests assume that a TPM2.0 simulator (for instance, [IBM's simulator](https://sourceforge.net/projects/ibmswtpm2/))
 is listening locally on TCP port 2321.

--- a/README.md
+++ b/README.md
@@ -13,12 +13,37 @@ Utilities for interacting with a TPM2.0 used for access to the Xaptum Edge Netwo
 
 ## Building
 
+`xaptum-tpm` uses CMake as its build system:
+
 ```bash
+# Create a subdirectory to hold the build
 mkdir -p build
 cd build
-cmake .. -DCMAKE_BUILD_TYPE=Debug
-cmake --build . -- -j4
+
+# Configure the build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
+
+# Build the library
+cmake --build .
 ```
+
+In addition to the standard CMake options the following configuration
+options and variables are supported.
+
+If `BUILD_SHARED_LIBS` is set, the shared library is built. If
+`BUILD_STATIC_LIBS` is set, the static library is built. If both are
+set, both libraries will be built.  If neither is set, the static
+library will be built.
+
+`STATIC_SUFFIX`, if defined, will be appended to the static library
+name.  For example,
+
+```bash
+cmake .. -DBUILD_STATIC_LIBS=ON -DSTATIC_SUFFIX=_static
+cmake --build .
+```
+
+will create a static library named `libxaptum_tpm_static.a`.
 
 ## Running the tests
 The tests assume that a TPM2.0 simulator (for instance, [IBM's simulator](https://sourceforge.net/projects/ibmswtpm2/))

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ cmake --build .
 
 will create a static library named `libxaptum_tpm_static.a`.
 
+### Force Position Independent Code (-fPIC)
+Set the standard CMake variable `CMAKE_POSITION_INDEPENDENT_CODE` to
+`ON` to force compilation with `-fPIC` for static libraries.  The
+default is `OFF` for static libraries and `ON` for shared libraries.
+
 ### Disable Building of Tests
 Set the standard CMake variable `BUILD_TESTING` to `OFF` to disable
 the building of tests.  The default value is `ON`.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cmake .. -DBUILD_STATIC_LIBS=ON -DSTATIC_SUFFIX=_static
 cmake --build .
 ```
 
-will create a static library named `libxaptum_tpm_static.a`.
+will create a static library named `libxaptum-tpm_static.a`.
 
 ### Force Position Independent Code (-fPIC)
 Set the standard CMake variable `CMAKE_POSITION_INDEPENDENT_CODE` to

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,12 +25,16 @@ foreach(case_file ${TEST_SRCS})
 
   add_executable(${case_name} ${case_file})
 
-  target_link_libraries(${case_name}
-    PRIVATE xaptum_tpm-static
-  )
+  if(BUILD_SHARED_LIBS)
+    target_link_libraries(${case_name} PRIVATE xaptum_tpm)
+  else()
+    target_link_libraries(${case_name} PRIVATE xaptum_tpm_static)
+  endif()
+
   target_include_directories(${case_name}
     PRIVATE ${PROJECT_SOURCE_DIR}/include/
   )
+
   set_target_properties(${case_name} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CURRENT_TEST_BINARY_DIR}
   )
@@ -39,5 +43,4 @@ foreach(case_file ${TEST_SRCS})
            COMMAND ${CURRENT_TEST_BINARY_DIR}/${case_name}
   )
 
-  add_dependencies(${case_name} xaptum_tpm-static)
 endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,13 +14,7 @@
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-include(CTest)
-
-set(CURRENT_TEST_BINARY_DIR ${CMAKE_BINARY_DIR}/testBin/)
-
-file(GLOB_RECURSE TEST_SRCS "*.c")
-
-foreach(case_file ${TEST_SRCS})
+macro(add_test_case case_file)
   get_filename_component(case_name ${case_file} NAME_WE)
 
   add_executable(${case_name} ${case_file})
@@ -39,8 +33,17 @@ foreach(case_file ${TEST_SRCS})
     RUNTIME_OUTPUT_DIRECTORY ${CURRENT_TEST_BINARY_DIR}
   )
 
-  add_test(NAME ${case_name}
-           COMMAND ${CURRENT_TEST_BINARY_DIR}/${case_name}
+  add_test(NAME ${case_name} 
+    COMMAND ${CURRENT_TEST_BINARY_DIR}/${case_name}
   )
+endmacro()
 
-endforeach()
+if(BUILD_TESTING)
+  set(CURRENT_TEST_BINARY_DIR ${CMAKE_BINARY_DIR}/testBin/)
+
+  file(GLOB_RECURSE TEST_SRCS "*.c")
+  foreach(case_file ${TEST_SRCS})
+    add_test_case(${case_file})
+  endforeach()
+
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,20 +24,20 @@ foreach(case_file ${TEST_SRCS})
   get_filename_component(case_name ${case_file} NAME_WE)
 
   add_executable(${case_name} ${case_file})
+
   target_link_libraries(${case_name}
-    PRIVATE xaptumtpm-static
-    )
+    PRIVATE xaptum_tpm-static
+  )
   target_include_directories(${case_name}
-          PRIVATE ${PROJECT_SOURCE_DIR}/include/
-          )
+    PRIVATE ${PROJECT_SOURCE_DIR}/include/
+  )
   set_target_properties(${case_name} PROPERTIES
-          RUNTIME_OUTPUT_DIRECTORY ${CURRENT_TEST_BINARY_DIR}
-          )
+    RUNTIME_OUTPUT_DIRECTORY ${CURRENT_TEST_BINARY_DIR}
+  )
 
   add_test(NAME ${case_name}
-          COMMAND ${CURRENT_TEST_BINARY_DIR}/${case_name}
-          )
+           COMMAND ${CURRENT_TEST_BINARY_DIR}/${case_name}
+  )
 
-  add_dependencies(${case_name} xaptumtpm-static)
+  add_dependencies(${case_name} xaptum_tpm-static)
 endforeach()
-

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,9 +20,9 @@ macro(add_test_case case_file)
   add_executable(${case_name} ${case_file})
 
   if(BUILD_SHARED_LIBS)
-    target_link_libraries(${case_name} PRIVATE xaptum_tpm)
+    target_link_libraries(${case_name} PRIVATE xaptum-tpm)
   else()
-    target_link_libraries(${case_name} PRIVATE xaptum_tpm_static)
+    target_link_libraries(${case_name} PRIVATE xaptum-tpm_static)
   endif()
 
   target_include_directories(${case_name}

--- a/xaptum-tpm.pc.in
+++ b/xaptum-tpm.pc.in
@@ -3,8 +3,8 @@ exec_prefix=${prefix}
 libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
-Name: XaptumTPM
+Name: xaptum-tpm
 Description: Library for the TPM 2.0 used to access the Xaptum ENF
 Version: @XAPTUM_TPM_VERSION@
-Libs: -L{libdir} -lxaptum_tpm
+Libs: -L{libdir} -lxaptum-tpm
 Cflags: -I${includedir}

--- a/xaptum_tpm.pc.in
+++ b/xaptum_tpm.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: XaptumTPM
+Description: Library for the TPM 2.0 used to access the Xaptum ENF
+Version: @XAPTUM_TPM_VERSION@
+Libs: -L{libdir} -lxaptum_tpm
+Cflags: -I${includedir}


### PR DESCRIPTION
This patch series adds three major changes:

1. renames the library from xaptumtpm to `xaptum-tpm`. I personally find it more readable, especially if we end up with more `xaptumxxx/xaptum-xxx` libraries.

2. Uses standard CMake conventions for configuring shared vs. static builds, `-fPIC`, etc.  These are documented in the README, so I won't list them here. Better to review the README and have me fix that if its not clear.

   The main motivations here are more consistency with users' expectations and better integration with other ecosystem tools (e.g., BuildRoot) that can build CMake packages.

3. Add `pkg-config` support and `*Config.cmake`project export support.  These make it easy for other projects using `pkg-config` or CMake to use a system-installed version of this library.
  