### PR TITLE
Fix README and install-ibm-tpm script

### DIFF
--- a/.travis/install-ibm-tpm2.sh
+++ b/.travis/install-ibm-tpm2.sh
@@ -28,7 +28,7 @@ cd ${install_dir}
 
 mkdir -p ./tpm
 cd ./tpm
-wget https://sourceforge.net/projects/ibmswtpm2/files/ibmtpm${tpm_version}.tar
+wget https://sourceforge.net/projects/ibmswtpm2/files/ibmtpm${tpm_version}.tar --no-check-certificate
 tar xvf ibmtpm${tpm_version}.tar
 cd ./src/
 make
@@ -36,7 +36,7 @@ cd ../../
 
 mkdir -p ./tss
 cd ./tss
-wget https://sourceforge.net/projects/ibmtpm20tss/files/ibmtss${tss_version}.tar
+wget https://sourceforge.net/projects/ibmtpm20tss/files/ibmtss${tss_version}.tar --no-check-certificate
 tar xvf ibmtss${tss_version}.tar
 cd ./utils/
 make

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The tests assume that a TPM2.0 simulator (for instance, [IBM's simulator](https:
 is listening locally on TCP port 2321.
 This can be achieved by running the following in the background, before starting the tests:
 ```
-.travis/install-ibm-tpm2.sh
+.travis/install-ibm-tpm2.sh <installation dir>
 .travis/run-ibm-tpm2.sh
 ```
 


### PR DESCRIPTION
Followed TPM simulator installation in the README
>.travis/install-ibm-tpm2.sh

usage: .travis/install-ibm-tpm2.sh absolute-path-to-tpm-simulator-installation-directory

Then I tried

>.travis/install-ibm-tpm2.sh /Users/iguberman/TPM_SIMULATOR/
--2018-01-18 10:59:58--  https://sourceforge.net/projects/ibmswtpm2/files/ibmtpm532.tar
Resolving sourceforge.net... 216.34.181.60
Connecting to sourceforge.net|216.34.181.60|:443... connected.
ERROR: cannot verify sourceforge.net's certificate, issued by ‘CN=COMODO RSA Domain Validation Secure Server CA,O=COMODO CA Limited,L=Salford,ST=Greater Manchester,C=GB’:
  Unable to locally verify the issuer's authority.
To connect to sourceforge.net insecurely, use `--no-check-certificate'.
tar: ibmtpm532.tar: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
.travis/install-ibm-tpm2.sh: line 33: cd: ./src/: No such file or directory
make: *** No targets specified and no makefile found.  Stop.
--2018-01-18 10:59:58--  https://sourceforge.net/projects/ibmtpm20tss/files/ibmtss593.tar
Resolving sourceforge.net... 216.34.181.60
Connecting to sourceforge.net|216.34.181.60|:443... connected.
ERROR: cannot verify sourceforge.net's certificate, issued by ‘CN=COMODO RSA Domain Validation Secure Server CA,O=COMODO CA Limited,L=Salford,ST=Greater Manchester,C=GB’:
  Unable to locally verify the issuer's authority.
To connect to sourceforge.net insecurely, use `--no-check-certificate'.
tar: ibmtss593.tar: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
.travis/install-ibm-tpm2.sh: line 41: cd: ./utils/: No such file or directory
make: *** No targets specified and no makefile found.  Stop.


It works after adding `--no-check-certificate` to both wget commands. 
