### PR TITLE
Use my new github mirror of IBM's sourceforge page for the TPM simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 build/
-ibm-tpm-simulator/
+ibm-tpm2-simulator-mirror/

--- a/.travis/install-ibm-tpm2.sh
+++ b/.travis/install-ibm-tpm2.sh
@@ -18,25 +18,22 @@ if [[ $# -ne 1 ]]; then
         exit 1
 fi
 
-tpm_version=532
-tss_version=593
+installation_dir="$1"
 
-install_dir="$1"
+if [[ ! -d "$installation_dir" ]]; then
+        git clone https://github.com/zanebeckwith/ibm-tpm2-simulator-mirror "$installation_dir"
+fi
 
-mkdir -p ${install_dir}
-cd ${install_dir}
+pushd $installation_dir 
 
-mkdir -p ./tpm
-cd ./tpm
-wget https://sourceforge.net/projects/ibmswtpm2/files/ibmtpm${tpm_version}.tar
-tar xvf ibmtpm${tpm_version}.tar
-cd ./src/
+pushd ./tpm
 make
-cd ../../
+popd
 
-mkdir -p ./tss
-cd ./tss
-wget https://sourceforge.net/projects/ibmtpm20tss/files/ibmtss${tss_version}.tar
-tar xvf ibmtss${tss_version}.tar
-cd ./utils/
+pushd ./tss
+pushd ./utils/
 make
+popd
+popd
+
+popd

--- a/.travis/run-ibm-tpm2.sh
+++ b/.travis/run-ibm-tpm2.sh
@@ -18,14 +18,20 @@ if [[ $# -ne 1 ]]; then
         exit 1
 fi
 
-cd "$1"
+installation_dir="$1"
 
 pkill tpm_server
-cd ./tpm/src/
+
+pushd $installation_dir
+
+pushd tpm
 ./tpm_server -rm &
 sleep 2
-cd ../..
+popd
 
-cd ./tss/utils/
+pushd tss/utils/
 ./powerup
 ./startup
+popd
+
+popd


### PR DESCRIPTION
The SourceForge page has been having trouble, which causes any of our travis-ci builds that need TPM simulators for testing to fail.