### PR TITLE
readme: reorganize and augment installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,55 @@ Utilities for interacting with a TPM2.0 used for access to the Xaptum Edge Netwo
 
 [![Build Status](https://travis-ci.org/xaptum/xaptum-tpm.svg?branch=master)](https://travis-ci.org/xaptum/xaptum-tpm)
 
-## Requirements
-- cmake version >= 3.0
-- A C99-compliant compiler
-- Currently, only supports POSIX platforms
+## Installation
 
-## Building
+`xaptum-tpm` is available for the following distributions. It may also
+be built from source.
 
-`xaptum-tpm` uses CMake as its build system:
+### Debian (Jessie or Stretch)
+
+Install the repository GPG key.
+
+``` bash
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys c615bfaa7fe1b4ca
+```
+
+Add the repository to APT sources, replacing `<dist>` with either `jessie`
+or `stretch`.
+
+``` bash
+echo "deb http://dl.bintray.com/xaptum/deb <dist> main" | sudo tee -a /etc/apt/sources.list
+sudo apt-get update
+```
+
+Install the library.
+
+``` bash
+sudo apt-get install libxaptum-tpm-dev
+```
+
+### Homebrew (MacOS)
+
+Tap the Xaptum repository.
+
+``` bash
+brew tap xaptum/xaptum
+```
+
+Install the library.
+``` bash
+brew install xaptum-tpm
+```
+
+## Installation from Source
+
+### Build Dependencies
+
+* CMake (version 3.0 or higher)
+* A C99-compliant compiler
+* A POSIX-compliant platform
+
+### Building
 
 ```bash
 # Create a subdirectory to hold the build
@@ -21,54 +62,31 @@ mkdir -p build
 cd build
 
 # Configure the build
-cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
+cmake .. -DCMAKE_BUILD_TYPE=Release
 
 # Build the library
 cmake --build .
 ```
 
-In addition to the standard CMake options the following configuration
-options and variables are supported.
+### CMake Options
 
-### Static vs Shared Libary
-If `BUILD_SHARED_LIBS` is set, the shared library is built. If
-`BUILD_STATIC_LIBS` is set, the static library is built. If both are
-set, both libraries will be built.  If neither is set, the static
-library will be built.
+The following CMake configuration options are supported.
 
-### Static Library Name
-`STATIC_SUFFIX`, if defined, will be appended to the static library
-name.  For example,
+| Option                          | Values          | Default    | Description                                     |
+|---------------------------------|-----------------|------------|-------------------------------------------------|
+| CMAKE_BUILD_TYPE                | Release         |            | With full optimizations.                        |
+|                                 | Debug           |            | With debug symbols.                             |
+|                                 | RelWithDebInfo  |            | With full optimizations and debug symbols.      |
+|                                 | RelWithSanitize |            | With address and undefined-behavior sanitizers. |
+| CMAKE_INSTALL_PREFIX            | <string>        | /usr/local | The directory to install the library in.        |
+| BUILD_SHARED_LIBS               | ON, OFF         | ON         | Build shared libraries.                         |
+| BUILD_STATIC_LIBS               | ON, OFF         | OFF        | Build static libraries.                         |
+| BUILD_TESTING                   | ON, OFF         | ON         | Build the test suite.                           |
+| STATIC_SUFFIX                   | <string>        | <none>     | Appends a suffix to the static lib name.        |
+| CMAKE_POSITION_INDEPENDENT_CODE | ON, OFF         | ON         | Compile static libs with `-fPIC`.               |
 
-```bash
-cmake .. -DBUILD_STATIC_LIBS=ON -DSTATIC_SUFFIX=_static
-cmake --build .
-```
+### Testing
 
-will create a static library named `libxaptum-tpm_static.a`.
-
-### Force Position Independent Code (-fPIC)
-Set the standard CMake variable `CMAKE_POSITION_INDEPENDENT_CODE` to
-`ON` to force compilation with `-fPIC` for static libraries.  The
-default is `OFF` for static libraries and `ON` for shared libraries.
-
-### Disable Building of Tests
-Set the standard CMake variable `BUILD_TESTING` to `OFF` to disable
-the building of tests.  The default value is `ON`.
-
-## Installation
-
-CMake creates a target for installation.
-
-```bash
-cd build
-cmake --build . --target install
-```
-
-Set the `CMAKE_INSTALL_PREFIX` variable when configuring the build to
-modify the installation location.
-
-## Running the tests
 The tests assume that a TPM2.0 simulator (for instance, [IBM's simulator](https://sourceforge.net/projects/ibmswtpm2/))
 is listening locally on TCP port 2321.
 This can be achieved by running the following in the background, before starting the tests:
@@ -81,4 +99,11 @@ Then, to run the test suite:
 ```bash
 cd build
 ctest -V
+```
+
+### Installing
+
+```bash
+cd build
+cmake --build . --target install
 ```


### PR DESCRIPTION
This series changes the README in two ways:

1. Adds installation instructions for Homebrew and Debian.

2. Reorganizes the build instructions to be more succinct.

A later PR should as a "Usage" section that briefly describes the functions available in the library.