### PR TITLE
Fully export cmake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if(BUILD_SHARED_LIBS)
   )
 
   install(TARGETS xaptum-tpm
-          EXPORT ${CMAKE_PROJECT_NAME}Targets
+          EXPORT xaptum-tpm-targets
           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -100,7 +100,7 @@ if(BUILD_STATIC_LIBS)
   )
 
   install(TARGETS xaptum-tpm_static
-          EXPORT ${CMAKE_PROJECT_NAME}Targets
+          EXPORT xaptum-tpm-targets
           RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
           LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
           ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
@@ -121,9 +121,30 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/xaptum-tpm.pc DESTINATION ${CMAKE_INST
 ################################################################################
 # CMake export
 ################################################################################
-install(EXPORT ${CMAKE_PROJECT_NAME}Targets
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
-        FILE        ${CMAKE_PROJECT_NAME}Config.cmake
+set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/xaptum-tpm)
+
+install(EXPORT xaptum-tpm-targets
+        FILE xaptum-tpm-targets.cmake
+        NAMESPACE xaptum-tpm::
+        DESTINATION ${INSTALL_CONFIGDIR}
+)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/xaptum-tpm-config-version.cmake
+  VERSION ${XAPTUM_TPM_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/xaptum-tpm-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/xaptum-tpm-config.cmake
+  INSTALL_DESTINATION ${INSTALL_CONFIGDIR}
+)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/xaptum-tpm-config.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/xaptum-tpm-config-version.cmake
+  DESTINATION ${INSTALL_CONFIGDIR}
 )
 
 add_subdirectory(test)

--- a/xaptum-tpm-config.cmake.in
+++ b/xaptum-tpm-config.cmake.in
@@ -1,0 +1,7 @@
+get_filename_component(xaptum-tpm_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+if(NOT TARGET xaptum-tpm::xaptum-tpm)
+    include("${xaptum-tpm_CMAKE_DIR}/xaptum-tpm-targets.cmake")
+endif()
+
+set(xaptum-tpm_LIBRARIES xaptum-tpm::xaptum-tpm)

--- a/xaptum-tpm.pc.in
+++ b/xaptum-tpm.pc.in
@@ -1,4 +1,4 @@
-prefix=@CMAKE_INSTALL_PREFIX@
+prefix="@CMAKE_INSTALL_PREFIX@"
 exec_prefix=${prefix}
 libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@


### PR DESCRIPTION
Previously the targets were exported to a `xaptum-tpm-config.cmake` file, but 

1. A `xaptum-tpm-config-version.cmake` file was not exported, so downstream could not use `find_package(xaptum-tpm VERSION X.X.X)`.

1. The `xaptum-tpm-config.cmake` file was created directly by `install(EXPORT ...)`, so there was no chance to add any other required config.

    For example, `find_package(...)` calls for any dependencies of `xaptum-tpm` (it currently has none anyway) and setting the `xaptum-tpm_LIBRARIES` variable (to support old-style usage in downstream).  

    Now, the generated file is called `xaptum-tpm-target.cmake` and is included by a new `xaptum-tpm-config.cmake` that sets the `xaptum_tpm_LIBRARIES` definition.

This series also adds quotes the prefix path in the `pkg-config`script to handle spaces in the install path.
