### PR TITLE
Set compiler flags (e.g. -std= and -Werror) as add_compile_options.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,8 @@ project(xaptum-tpm
 include(GNUInstallDirs)
 include(CTest)
       
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Wall -Wextra -Wno-missing-field-initializers -std=c99 -D_POSIX_C_SOURCE=200112L")
+add_compile_options(-std=c99 -Werror -Wall -Wextra -Wno-missing-field-initializers)
+add_definitions(-D_POSIX_C_SOURCE=200112L)
 set(CMAKE_C_FLAGS_RELWITHSANITIZE "${CMAKE_C_FLAGS_RELWITHSANITIZE} -O2 -g -fsanitize=address,undefined -fsanitize=unsigned-integer-overflow")
 
 option(BUILD_SHARED_LIBS "Build as a shared library" ON)


### PR DESCRIPTION
This is to avoid polluting the global variables