### PR TITLE
Add device-file TCTI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
   - env: TYPE=RELEASE
     before_script:
       - .travis/install-ibm-tpm2.sh ${IBM_TPM_DIR}
-      - cmake . -DCMAKE_BUILD_TYPE=Release
+      - cmake . -DCMAKE_BUILD_TYPE=Release -DTEST_USE_TCP_TPM=ON
     script:
       - cmake --build . -- -j2
       - .travis/run-ibm-tpm2.sh ${IBM_TPM_DIR}
@@ -37,7 +37,7 @@ jobs:
   - env: TYPE=DEBUG
     before_script:
       - .travis/install-ibm-tpm2.sh ${IBM_TPM_DIR}
-      - cmake . -DCMAKE_BUILD_TYPE=Debug
+      - cmake . -DCMAKE_BUILD_TYPE=Debug -DTEST_USE_TCP_TPM=ON
     script:
       - cmake --build . -- -j2
       - .travis/run-ibm-tpm2.sh ${IBM_TPM_DIR}
@@ -48,7 +48,7 @@ jobs:
     compiler: clang
     before_script:
       - .travis/install-ibm-tpm2.sh ${IBM_TPM_DIR}
-      - cmake . -DCMAKE_BUILD_TYPE=Release
+      - cmake . -DCMAKE_BUILD_TYPE=Release -DTEST_USE_TCP_TPM=ON
     script:
       - cmake --build . -- -j2
       - .travis/run-ibm-tpm2.sh ${IBM_TPM_DIR}
@@ -61,7 +61,7 @@ jobs:
         packages:
           - cppcheck
     before_script:
-      - cmake . -DCMAKE_BUILD_TYPE=Release
+      - cmake . -DCMAKE_BUILD_TYPE=Release -DTEST_USE_TCP_TPM=ON
     script:
       - cmake --build . -- -j2
       - .travis/run-cppcheck.sh
@@ -72,7 +72,7 @@ jobs:
     compiler: clang
     before_script:
       - .travis/install-ibm-tpm2.sh ${IBM_TPM_DIR}
-      - cmake . -DCMAKE_BUILD_TYPE=RelWithSanitize
+      - cmake . -DCMAKE_BUILD_TYPE=RelWithSanitize -DTEST_USE_TCP_TPM=ON
     script:
       - cmake --build . -- -j2
       - .travis/run-ibm-tpm2.sh ${IBM_TPM_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(xaptum-tpm
         LANGUAGES C
-        VERSION "0.5.1"
+        VERSION "0.5.2"
 )
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ set(XAPTUM_TPM_SOVERSION ${PROJECT_VERSION_MAJOR})
 set(XAPTUM_TPM_SRCS
     src/xaptum/nvram.c
 
+    src/tss2_tcti_device.c
     src/tss2_tcti_socket.c
     src/tss2_sys_context_allocation.c
     src/tss2_sys_clear.c

--- a/README.md
+++ b/README.md
@@ -75,7 +75,13 @@ The following CMake configuration options are supported.
 
 ### Testing
 
-The TPM tests require a [TPM 2.0
+By default, the tests use a device-file-based TCTI.
+For this reason, `sudo` privileges may be required to run them.
+
+The tests can instead be build to use a TCP-socket-based TCTI,
+by using the CMake option `TEST_USE_TCP_TPM=ON`.
+
+If using the TCP-socket-based TCTI, the tests require a [TPM 2.0
 simulator](https://sourceforge.net/projects/ibmswtpm2/) running
 locally on TCP port 2321.
 

--- a/include/tss2/tss2_tcti_device.h
+++ b/include/tss2/tss2_tcti_device.h
@@ -1,0 +1,52 @@
+/******************************************************************************
+ *
+ * Copyright 2018 Xaptum, Inc.
+ * 
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * This implementation is blocking ONLY.
+ * Also, all buffers are assumed to be large enough,
+ * and pointers are NOT checked for NULL.
+ *
+ *****************************************************************************/
+
+#ifndef XAPTUM_TPM_TSS2_TCTI_DEVICE_H
+#define XAPTUM_TPM_TSS2_TCTI_DEVICE_H
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <tss2/tss2_tcti.h>
+
+#include <stddef.h>
+
+size_t
+tss2_tcti_getsize_device();
+
+TSS2_RC
+tss2_tcti_init_device(const char *dev_file_path,
+                      size_t dev_file_path_length,
+                      TSS2_TCTI_CONTEXT *tcti_context);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/include/tss2/tss2_tpm2_types.h
+++ b/include/tss2/tss2_tpm2_types.h
@@ -27,6 +27,7 @@ extern "C" {
 #include <stdint.h>
 
 // TODO: Make sure these make sense (they should work well with an Infineon SLB9670)
+//  COMMANDRESPONSE_SIZE is probably too big. SLB9670 has an I/O buffer of 1280 B
 #define COMMANDRESPONSE_SIZE 4096
 #define MAX_SYM_DATA 128
 #define MAX_ECC_KEY_BYTES 32

--- a/src/tss2_tcti_device.c
+++ b/src/tss2_tcti_device.c
@@ -1,0 +1,321 @@
+/******************************************************************************
+ *
+ * Copyright 2018 Xaptum, Inc.
+ * 
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include <tss2/tss2_tcti_device.h>
+#include <tss2/tss2_tpm2_types.h>
+
+#include "internal/tcti_common.h"
+#include "internal/marshal.h"
+
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+
+#define DEFAULT_LOCALITY 3
+#define SIMULATOR_SEND_COMMAND 8
+#define SIMULATOR_SESSION_END 20
+#define MAX_DEV_FILE_PATH_LENGTH 64
+#define DEFAULT_DEV_FILE_PATH_LENGTH 9
+
+static const char* DEFAULT_DEV_FILE_PATH = "/dev/tpm0";
+
+enum _TCTI_DEVICE_STATE {
+    _TCTI_DEVICE_STATE_READY,
+    _TCTI_DEVICE_STATE_AWAITING_RESPONSE,
+};
+
+typedef struct {
+    uint64_t magic;
+    uint32_t version;
+    TSS2_RC (*transmit)( TSS2_TCTI_CONTEXT *tctiContext, size_t size,
+            uint8_t *command);
+    TSS2_RC (*receive) (TSS2_TCTI_CONTEXT *tctiContext, size_t *size,
+            uint8_t *response, int32_t timeout);
+    TSS2_RC (*finalize) (TSS2_TCTI_CONTEXT *tctiContext);
+    TSS2_RC (*cancel) (TSS2_TCTI_CONTEXT *tctiContext);
+    TSS2_RC (*getPollHandles) (TSS2_TCTI_CONTEXT *tctiContext,
+            TSS2_TCTI_POLL_HANDLE *handles, size_t *num_handles);
+    TSS2_RC (*setLocality) (TSS2_TCTI_CONTEXT *tctiContext, uint8_t locality);
+
+    char dev_file_path[MAX_DEV_FILE_PATH_LENGTH];
+    FILE* file_ptr;
+    enum _TCTI_DEVICE_STATE state;
+} TSS2_TCTI_CONTEXT_OPAQUE_DEVICE;
+
+#ifdef VERBOSE_LOGGING
+#define TCTI_VERBOSE_LOGGING
+#endif
+
+static
+TSS2_RC transmit_device(TSS2_TCTI_CONTEXT *tcti_context,
+                        size_t size,
+                        uint8_t *command);
+
+static
+TSS2_RC receive_device(TSS2_TCTI_CONTEXT *tcti_context,
+                       size_t *size,
+                       uint8_t *response,
+                       int32_t timeout);
+
+static
+TSS2_RC finalize_device(TSS2_TCTI_CONTEXT *tcti_context);
+
+static
+TSS2_RC cancel_device(TSS2_TCTI_CONTEXT *tcti_context);
+
+static
+TSS2_RC
+getPollHandles_device(TSS2_TCTI_CONTEXT *tcti_context,
+                      TSS2_TCTI_POLL_HANDLE *handles,
+                      size_t *num_handles);
+
+static
+TSS2_RC
+setLocality_device(TSS2_TCTI_CONTEXT *tcti_context,
+                   uint8_t locality);
+
+static
+TSS2_RC
+send_all(FILE* file_ptr,
+         uint8_t *in,
+         size_t requested_length);
+
+size_t
+tss2_tcti_getsize_device()
+{
+    return sizeof(TSS2_TCTI_CONTEXT_OPAQUE_DEVICE);
+}
+
+TSS2_RC
+tss2_tcti_init_device(const char *dev_file_path,
+                      size_t dev_file_path_length,
+                      TSS2_TCTI_CONTEXT *tcti_context)
+{
+    TSS2_TCTI_CONTEXT_OPAQUE_DEVICE *cast_context = (TSS2_TCTI_CONTEXT_OPAQUE_DEVICE*)tcti_context;
+
+    assert(DEFAULT_DEV_FILE_PATH_LENGTH == strlen(DEFAULT_DEV_FILE_PATH));
+    if (NULL == dev_file_path) {
+        memcpy(cast_context->dev_file_path, DEFAULT_DEV_FILE_PATH, DEFAULT_DEV_FILE_PATH_LENGTH);
+    } else if (MAX_DEV_FILE_PATH_LENGTH < dev_file_path_length) {
+        return TSS2_BASE_RC_INSUFFICIENT_BUFFER;
+    } else {
+        memcpy(cast_context->dev_file_path, dev_file_path, dev_file_path_length);
+    }
+
+    cast_context->magic = TCTI_MAGIC;
+    cast_context->version = TCTI_VERSION;
+    cast_context->transmit = transmit_device;
+    cast_context->receive = receive_device;
+    cast_context->finalize = finalize_device;
+    cast_context->cancel = cancel_device;
+    cast_context->getPollHandles = getPollHandles_device;
+    cast_context->setLocality = setLocality_device;
+
+    cast_context->state = _TCTI_DEVICE_STATE_READY;
+    cast_context->file_ptr = NULL;
+
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+getPollHandles_device(TSS2_TCTI_CONTEXT *tcti_context,
+                      TSS2_TCTI_POLL_HANDLE *handles,
+                      size_t *num_handles)
+{
+    (void)tcti_context;
+    (void)handles;
+    (void)num_handles;
+
+    return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+}
+
+TSS2_RC
+setLocality_device(TSS2_TCTI_CONTEXT *tcti_context,
+                   uint8_t locality)
+{
+    (void)tcti_context;
+    (void)locality;
+
+    return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+}
+
+TSS2_RC transmit_device(TSS2_TCTI_CONTEXT *tcti_context,
+                        size_t size,
+                        uint8_t *command)
+{
+    TSS2_TCTI_CONTEXT_OPAQUE_DEVICE *cast_context = (TSS2_TCTI_CONTEXT_OPAQUE_DEVICE*)tcti_context;
+    TSS2_RC send_ret = TSS2_RC_SUCCESS;
+
+    if (_TCTI_DEVICE_STATE_READY != cast_context->state) {
+#ifdef TCTI_VERBOSE_LOGGING
+        fprintf(stderr, "tcti_device::transmit - transmit called while awaiting a response\n");
+#endif
+        return TSS2_BASE_RC_BAD_SEQUENCE;
+    }
+
+    // Open file
+    cast_context->file_ptr = fopen(cast_context->dev_file_path, "r+");
+    if (NULL == cast_context->file_ptr) {
+#ifdef TCTI_VERBOSE_LOGGING
+        fprintf(stderr, "tcti_device::transmit - Error with fopen: (%d) %s\n", errno, strerror(errno));
+#endif
+        return TSS2_TCTI_RC_IO_ERROR; 
+    }
+
+    // Send the command.
+    send_ret = send_all(cast_context->file_ptr,
+                        command,
+                        size);
+    if (send_ret != TSS2_RC_SUCCESS) {
+        goto transmit_cleanup;
+    }
+#ifdef TCTI_VERBOSE_LOGGING
+    printf("tcti_device::transmit - command={");
+    for (size_t i=0; i < size; i++) {
+        printf("%#X", command[i]);
+        if (i != (size-1)) printf(", ");
+    }
+    printf("}\n");
+#endif
+
+transmit_cleanup:
+    if (TSS2_RC_SUCCESS != send_ret && cast_context->file_ptr) {
+        fclose(cast_context->file_ptr);
+        cast_context->file_ptr = NULL;
+    } else {
+        cast_context->state = _TCTI_DEVICE_STATE_AWAITING_RESPONSE;
+    }
+
+    return send_ret;
+}
+
+TSS2_RC receive_device(TSS2_TCTI_CONTEXT *tcti_context,
+                       size_t *size,
+                       uint8_t *response,
+                       int32_t timeout)
+{
+    TSS2_RC recv_ret = TSS2_RC_SUCCESS;
+
+    TSS2_TCTI_CONTEXT_OPAQUE_DEVICE *cast_context = (TSS2_TCTI_CONTEXT_OPAQUE_DEVICE*)tcti_context;
+
+    // Nb. We don't support timeouts
+    if (TSS2_TCTI_TIMEOUT_BLOCK != timeout) {
+        recv_ret = TSS2_TCTI_RC_NOT_IMPLEMENTED;
+        goto receive_cleanup;
+    }
+
+    // Nb. We don't support reporting the size.
+    //   A caller must give us enough buffer to read the entire response in one go.
+    if (NULL == response || NULL == size) {
+        recv_ret = TSS2_BASE_RC_BAD_REFERENCE;
+        goto receive_cleanup;
+    }
+
+    if (_TCTI_DEVICE_STATE_AWAITING_RESPONSE != cast_context->state) {
+#ifdef TCTI_VERBOSE_LOGGING
+        fprintf(stderr, "tcti_device::receive - receive called without matching transmit\n");
+#endif
+        recv_ret = TSS2_BASE_RC_BAD_SEQUENCE;
+        goto receive_cleanup;
+    }
+
+    size_t fread_ret = fread(response, 1, *size, cast_context->file_ptr);
+    if (0 == fread_ret && ferror(cast_context->file_ptr)) {
+#ifdef TCTI_VERBOSE_LOGGING
+        fprintf(stderr, "tcti_device::receive - Error with fread: (%d) %s\n", errno, strerror(errno));
+#endif
+        recv_ret = TSS2_TCTI_RC_IO_ERROR; 
+        goto receive_cleanup;
+    }
+    
+    if (!feof(cast_context->file_ptr)) {
+#ifdef TCTI_VERBOSE_LOGGING
+        fprintf(stderr, "tcti_device::receive - Supplied buffer too small for response\n");
+#endif
+        recv_ret = TSS2_TCTI_RC_INSUFFICIENT_BUFFER;
+        goto receive_cleanup;
+    }
+
+receive_cleanup:
+    if (TSS2_RC_SUCCESS == recv_ret) {
+        *size = (size_t)fread_ret;
+#ifdef TCTI_VERBOSE_LOGGING
+        printf("response={");
+        for (size_t i=0; i < *size; i++) {
+            printf("%#X", response[i]);
+            if (i != (*size-1)) printf(", ");
+        }
+        printf("}\n");
+#endif
+    } else {
+        *size = 0;
+    }
+
+    if (cast_context->file_ptr) {
+        fclose(cast_context->file_ptr);
+        cast_context->file_ptr = NULL;
+    }
+
+    cast_context->state = _TCTI_DEVICE_STATE_READY;
+
+    return recv_ret;
+}
+
+TSS2_RC finalize_device(TSS2_TCTI_CONTEXT *tcti_context)
+{
+    TSS2_TCTI_CONTEXT_OPAQUE_DEVICE *cast_context = (TSS2_TCTI_CONTEXT_OPAQUE_DEVICE*)tcti_context;
+
+    if (NULL != cast_context->file_ptr) {
+        fclose(cast_context->file_ptr);
+    }
+
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC cancel_device(TSS2_TCTI_CONTEXT *tcti_context)
+{
+    (void)tcti_context;
+    return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+}
+
+TSS2_RC
+send_all(FILE* file_ptr,
+         uint8_t *in,
+         size_t requested_length)
+{
+    size_t length_left = requested_length;
+    size_t bytes_sent = 0;
+    while (bytes_sent < requested_length) {
+        size_t fwrite_ret = fwrite((char*)&(in[bytes_sent]), 1, length_left, file_ptr);
+        if (0 == fwrite_ret) {
+#ifdef TCTI_VERBOSE_LOGGING
+            perror("tcti_device::send_all - ");
+#endif
+            return TSS2_TCTI_RC_IO_ERROR;
+        }
+
+        bytes_sent += (size_t)fwrite_ret;
+        length_left -= (size_t)fwrite_ret;
+    }
+
+    fflush(file_ptr);
+
+    return TSS2_RC_SUCCESS;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,12 @@
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
+option(TEST_USE_TCP_TPM "Use the socket-based TCTI in the tests" OFF)
+
+if(TEST_USE_TCP_TPM)
+        add_definitions(-DUSE_TCP_TPM)
+endif()
+
 macro(add_test_case case_file)
   get_filename_component(case_name ${case_file} NAME_WE)
 

--- a/test/create_load_evict-test.c
+++ b/test/create_load_evict-test.c
@@ -18,6 +18,7 @@
 
 #include <tss2/tss2_sys.h>
 #include <tss2/tss2_tcti_socket.h>
+#include <tss2/tss2_tcti_device.h>
 
 #include "test-utils.h"
 
@@ -55,14 +56,23 @@ int main(int argc, char *argv[])
 
 void initialize(struct test_context *ctx)
 {
+    TSS2_RC init_ret;
+
+#ifdef USE_TCP_TPM
     size_t tcti_ctx_size = tss2_tcti_getsize_socket();
 
     TSS2_TCTI_CONTEXT *tcti_ctx = malloc(tcti_ctx_size);
     TEST_EXPECT(NULL != tcti_ctx);
-    
-    TSS2_RC init_ret;
 
     init_ret = tss2_tcti_init_socket(hostname_g, port_g, tcti_ctx);
+#else
+    size_t tcti_ctx_size = tss2_tcti_getsize_device();
+
+    TSS2_TCTI_CONTEXT *tcti_ctx = malloc(tcti_ctx_size);
+    TEST_EXPECT(NULL != tcti_ctx);
+
+    init_ret = tss2_tcti_init_device(dev_file_path_g, dev_file_path_length_g, tcti_ctx);
+#endif
     TEST_ASSERT(TSS2_RC_SUCCESS == init_ret);
 
     size_t sapi_ctx_size = Tss2_Sys_GetContextSize(0);
@@ -189,7 +199,7 @@ int save_public_key_info(const struct test_context *ctx, const char* pub_key_fil
 
 int clear(struct test_context *ctx)
 {
-   TPMI_RH_CLEAR auth_handle = TPM_RH_PLATFORM;
+   TPMI_RH_CLEAR auth_handle = TPM_RH_LOCKOUT;
 
     TPMS_AUTH_COMMAND session_data = {
         .sessionHandle = TPM_RS_PW,

--- a/test/test-utils.h
+++ b/test/test-utils.h
@@ -20,6 +20,8 @@
 
 char *hostname_g = "localhost";
 const char *port_g = "2321";
+const char* dev_file_path_g = NULL;   // indicates to use default
+const size_t dev_file_path_length_g = 0;
 char *pub_key_filename_g = "pub_key.txt";
 char *handle_filename_g = "handle.txt";
 
@@ -48,7 +50,6 @@ char *handle_filename_g = "handle.txt";
         if (argc >= 2) { \
             hostname_g = argv[1]; \
         } \
-        printf("Connecting to %s:%s for TPM testing\n", hostname_g, port_g); \
         if (argc == 4) { \
             pub_key_filename_g = argv[2]; \
             handle_filename_g = argv[3]; \

--- a/test/tss2_sys_context-test.c
+++ b/test/tss2_sys_context-test.c
@@ -18,6 +18,7 @@
 
 #include <tss2/tss2_sys.h>
 #include <tss2/tss2_tcti_socket.h>
+#include <tss2/tss2_tcti_device.h>
 
 #include "test-utils.h"
 
@@ -41,15 +42,23 @@ int main(int argc, char *argv[])
 
 void initialize(struct test_context *ctx)
 {
+    TSS2_RC init_ret;
+
+#ifdef USE_TCP_TPM
     size_t tcti_ctx_size = tss2_tcti_getsize_socket();
 
     TSS2_TCTI_CONTEXT *tcti_ctx = malloc(tcti_ctx_size);
     TEST_EXPECT(NULL != tcti_ctx);
-    
-    TSS2_RC init_ret;
 
     init_ret = tss2_tcti_init_socket(hostname_g, port_g, tcti_ctx);
-    TEST_ASSERT(TSS2_RC_SUCCESS == init_ret);
+#else
+    size_t tcti_ctx_size = tss2_tcti_getsize_device();
+
+    TSS2_TCTI_CONTEXT *tcti_ctx = malloc(tcti_ctx_size);
+    TEST_EXPECT(NULL != tcti_ctx);
+
+    init_ret = tss2_tcti_init_device(dev_file_path_g, dev_file_path_length_g, tcti_ctx);
+#endif
 
     size_t sapi_ctx_size = Tss2_Sys_GetContextSize(0);
 

--- a/test/tss2_sys_createprimary-test.c
+++ b/test/tss2_sys_createprimary-test.c
@@ -18,6 +18,7 @@
 
 #include <tss2/tss2_sys.h>
 #include <tss2/tss2_tcti_socket.h>
+#include <tss2/tss2_tcti_device.h>
 
 #include "test-utils.h"
 
@@ -44,14 +45,23 @@ int main(int argc, char *argv[])
 
 void initialize(struct test_context *ctx)
 {
+    TSS2_RC init_ret;
+
+#ifdef USE_TCP_TPM
     size_t tcti_ctx_size = tss2_tcti_getsize_socket();
 
     TSS2_TCTI_CONTEXT *tcti_ctx = malloc(tcti_ctx_size);
     TEST_EXPECT(NULL != tcti_ctx);
-    
-    TSS2_RC init_ret;
 
     init_ret = tss2_tcti_init_socket(hostname_g, port_g, tcti_ctx);
+#else
+    size_t tcti_ctx_size = tss2_tcti_getsize_device();
+
+    TSS2_TCTI_CONTEXT *tcti_ctx = malloc(tcti_ctx_size);
+    TEST_EXPECT(NULL != tcti_ctx);
+
+    init_ret = tss2_tcti_init_device(dev_file_path_g, dev_file_path_length_g, tcti_ctx);
+#endif
     TEST_ASSERT(TSS2_RC_SUCCESS == init_ret);
 
     size_t sapi_ctx_size = Tss2_Sys_GetContextSize(0);
@@ -216,7 +226,7 @@ void full_test(const char* pub_key_filename, const char* handle_filename)
 
 int clear(struct test_context *ctx)
 {
-   TPMI_RH_CLEAR auth_handle = TPM_RH_PLATFORM;
+   TPMI_RH_CLEAR auth_handle = TPM_RH_LOCKOUT;
 
     TPMS_AUTH_COMMAND session_data = {
         .sessionHandle = TPM_RS_PW,

--- a/test/tss2_sys_hierarchychangeauth-test.c
+++ b/test/tss2_sys_hierarchychangeauth-test.c
@@ -18,6 +18,7 @@
 
 #include <tss2/tss2_sys.h>
 #include <tss2/tss2_tcti_socket.h>
+#include <tss2/tss2_tcti_device.h>
 
 #include "test-utils.h"
 
@@ -43,14 +44,23 @@ int main(int argc, char *argv[])
 
 void initialize(struct test_context *ctx)
 {
+    TSS2_RC init_ret;
+
+#ifdef USE_TCP_TPM
     size_t tcti_ctx_size = tss2_tcti_getsize_socket();
 
     TSS2_TCTI_CONTEXT *tcti_ctx = malloc(tcti_ctx_size);
     TEST_EXPECT(NULL != tcti_ctx);
-    
-    TSS2_RC init_ret;
 
     init_ret = tss2_tcti_init_socket(hostname_g, port_g, tcti_ctx);
+#else
+    size_t tcti_ctx_size = tss2_tcti_getsize_device();
+
+    TSS2_TCTI_CONTEXT *tcti_ctx = malloc(tcti_ctx_size);
+    TEST_EXPECT(NULL != tcti_ctx);
+
+    init_ret = tss2_tcti_init_device(dev_file_path_g, dev_file_path_length_g, tcti_ctx);
+#endif
     TEST_ASSERT(TSS2_RC_SUCCESS == init_ret);
 
     size_t sapi_ctx_size = Tss2_Sys_GetContextSize(0);

--- a/test/tss2_sys_nv-test.c
+++ b/test/tss2_sys_nv-test.c
@@ -18,6 +18,7 @@
 
 #include <tss2/tss2_sys.h>
 #include <tss2/tss2_tcti_socket.h>
+#include <tss2/tss2_tcti_device.h>
 
 #include "test-utils.h"
 
@@ -42,14 +43,23 @@ int main(int argc, char *argv[])
 
 void initialize(struct test_context *ctx)
 {
+    TSS2_RC init_ret;
+
+#ifdef USE_TCP_TPM
     size_t tcti_ctx_size = tss2_tcti_getsize_socket();
 
     TSS2_TCTI_CONTEXT *tcti_ctx = malloc(tcti_ctx_size);
     TEST_EXPECT(NULL != tcti_ctx);
-    
-    TSS2_RC init_ret;
 
     init_ret = tss2_tcti_init_socket(hostname_g, port_g, tcti_ctx);
+#else
+    size_t tcti_ctx_size = tss2_tcti_getsize_device();
+
+    TSS2_TCTI_CONTEXT *tcti_ctx = malloc(tcti_ctx_size);
+    TEST_EXPECT(NULL != tcti_ctx);
+
+    init_ret = tss2_tcti_init_device(dev_file_path_g, dev_file_path_length_g, tcti_ctx);
+#endif
     TEST_ASSERT(TSS2_RC_SUCCESS == init_ret);
 
     size_t sapi_ctx_size = Tss2_Sys_GetContextSize(0);

--- a/test/tss2_sys_sign-test.c
+++ b/test/tss2_sys_sign-test.c
@@ -18,6 +18,7 @@
 
 #include <tss2/tss2_sys.h>
 #include <tss2/tss2_tcti_socket.h>
+#include <tss2/tss2_tcti_device.h>
 
 #include "test-utils.h"
 
@@ -46,14 +47,23 @@ int main(int argc, char *argv[])
 
 void initialize(struct test_context *ctx)
 {
+    TSS2_RC init_ret;
+
+#ifdef USE_TCP_TPM
     size_t tcti_ctx_size = tss2_tcti_getsize_socket();
 
     TSS2_TCTI_CONTEXT *tcti_ctx = malloc(tcti_ctx_size);
     TEST_EXPECT(NULL != tcti_ctx);
-    
-    TSS2_RC init_ret;
 
     init_ret = tss2_tcti_init_socket(hostname_g, port_g, tcti_ctx);
+#else
+    size_t tcti_ctx_size = tss2_tcti_getsize_device();
+
+    TSS2_TCTI_CONTEXT *tcti_ctx = malloc(tcti_ctx_size);
+    TEST_EXPECT(NULL != tcti_ctx);
+
+    init_ret = tss2_tcti_init_device(dev_file_path_g, dev_file_path_length_g, tcti_ctx);
+#endif
     TEST_ASSERT(TSS2_RC_SUCCESS == init_ret);
 
     size_t sapi_ctx_size = Tss2_Sys_GetContextSize(0);
@@ -292,7 +302,7 @@ void full_test()
 
 int clear(struct test_context *ctx)
 {
-   TPMI_RH_CLEAR auth_handle = TPM_RH_PLATFORM;
+   TPMI_RH_CLEAR auth_handle = TPM_RH_LOCKOUT;
 
     TPMS_AUTH_COMMAND session_data = {
         .sessionHandle = TPM_RS_PW,


### PR DESCRIPTION
This PR adds a TCTI that supports the Linux kernel's TPM driver.

Tests, by default, now use this TCTI, but they can be built to use the TCP-based one with a CMake option.