### PR TITLE
Upgrade util to ecdsa

### DIFF
--- a/include/xaptum/tpm/nvram.h
+++ b/include/xaptum/tpm/nvram.h
@@ -30,8 +30,8 @@ extern "C" {
 #define XTPM_CRED_LENGTH             260
 #define XTPM_CRED_SIG_LENGTH         64
 #define XTPM_ROOT_ID_LENGTH          16
-#define XTPM_ROOT_PUBKEY_LENGTH      32
-#define XTPM_ROOT_ASN1CERT_LENGTH    276
+#define XTPM_ROOT_PUBKEY_LENGTH      65
+#define XTPM_ROOT_ASN1CERT_LENGTH    579
 #define XTPM_BASENAME_LENGTH         0  // size must be read from previous index
 #define XTPM_SERVER_ID_LENGTH        16
 

--- a/include/xaptum/tpm/nvram.h
+++ b/include/xaptum/tpm/nvram.h
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/util/xtpm_read_nvram.c
+++ b/util/xtpm_read_nvram.c
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/util/xtpm_read_nvram.c
+++ b/util/xtpm_read_nvram.c
@@ -173,7 +173,7 @@ parse_cli_args(int argc,
         "\t\t-d --tpm-device-file   TCTI device file, if tcti==device [default: '/dev/tpm0'].\n"
         "\t\t-a --tpm-ip-address    IP hostname of TPM TCP server, if tcti==socket [default: 'localhost'].\n"
         "\t\t-p --tpm-port          TCP port of TPM TCP server, if tcti==socket [default: 2321].\n"
-        "\t\t-o --output-file       Output file. [default: '<object-name>.bin']\n"
+        "\t\t-o --output-file       Output file. [default: '<object-name>.bin' or 'root.cert.asn1.bin']\n"
         "\tArguments:\n"
         "\t\tobject-name\tOne of gpk, cred, cred_sig, root_id, root_pubkey, root_asn1_cert, basename, or server_id\n"
         ;
@@ -249,7 +249,7 @@ parse_cli_args(int argc,
         } else if (0 == strcmp(argv[optind], "root_asn1_cert")) {
             ctx->obj_name = XTPM_ROOT_ASN1_CERTIFICATE;
             if (ctx->out_filename == NULL)
-                ctx->out_filename = "root_asn1_cert.bin";
+                ctx->out_filename = "root.cert.asn1.pem";
         } else if (0 == strcmp(argv[optind], "basename")) {
             ctx->obj_name = XTPM_BASENAME;
             if (ctx->out_filename == NULL)


### PR DESCRIPTION
The recent changes to `xtt`, switching the longterm key from Ed25519 to ECDSA with Secp256r1 (cf. XTT issue [38](https://github.com/xaptum/xtt/issues/38)) necessitates updating our utility that reads out the NVRAM values. This utility reads out the root public key and root PEM certificate, whose lengths have changed in the ECDSA change.