### PR TITLE
Use our new mirror of the IBM TPM simulator, for CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ compiler: gcc
 env:
   global:
   - IBM_TPM_DIR=${TRAVIS_BUILD_DIR}/ibm-tpm-simulator
+  - IBM_TPM_TAG=1332
 
 jobs:
   include:
@@ -26,7 +27,7 @@ jobs:
   # Release build, gcc
   - env: TYPE=RELEASE
     before_script:
-      - .travis/install-ibm-tpm2.sh ${IBM_TPM_DIR}
+      - .travis/install-ibm-tpm2.sh ${IBM_TPM_TAG} ${IBM_TPM_DIR}
       - cmake . -DCMAKE_BUILD_TYPE=Release -DTEST_USE_TCP_TPM=ON
     script:
       - cmake --build . -- -j2
@@ -36,7 +37,7 @@ jobs:
   # Debug build, to get code coverage with gcov
   - env: TYPE=DEBUG
     before_script:
-      - .travis/install-ibm-tpm2.sh ${IBM_TPM_DIR}
+      - .travis/install-ibm-tpm2.sh ${IBM_TPM_TAG} ${IBM_TPM_DIR}
       - cmake . -DCMAKE_BUILD_TYPE=Debug -DTEST_USE_TCP_TPM=ON
     script:
       - cmake --build . -- -j2
@@ -47,7 +48,7 @@ jobs:
   - env: TYPE=RELEASE-WITH-CLANG
     compiler: clang
     before_script:
-      - .travis/install-ibm-tpm2.sh ${IBM_TPM_DIR}
+      - .travis/install-ibm-tpm2.sh ${IBM_TPM_TAG} ${IBM_TPM_DIR}
       - cmake . -DCMAKE_BUILD_TYPE=Release -DTEST_USE_TCP_TPM=ON
     script:
       - cmake --build . -- -j2
@@ -71,7 +72,7 @@ jobs:
     sudo: true
     compiler: clang
     before_script:
-      - .travis/install-ibm-tpm2.sh ${IBM_TPM_DIR}
+      - .travis/install-ibm-tpm2.sh ${IBM_TPM_TAG} ${IBM_TPM_DIR}
       - cmake . -DCMAKE_BUILD_TYPE=RelWithSanitize -DTEST_USE_TCP_TPM=ON
     script:
       - cmake --build . -- -j2

--- a/.travis/install-ibm-tpm2.sh
+++ b/.travis/install-ibm-tpm2.sh
@@ -13,27 +13,22 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License
 
-if [[ $# -ne 1 ]]; then
-        echo "usage: $0 <absolute-path-to-tpm-simulator-installation-directory>"
+set -e
+
+if [[ $# -ne 2 ]]; then
+        echo "usage: $0 <git-tag> <absolute-path-to-tpm-simulator-installation-directory>"
         exit 1
 fi
 
-installation_dir="$1"
+source_tag="$1"
+installation_dir="$2"
 
 if [[ ! -d "$installation_dir" ]]; then
-        git clone https://github.com/zanebeckwith/ibm-tpm2-simulator-mirror "$installation_dir"
+        git clone --branch "${source_tag}" --depth 1 https://github.com/xaptum-eng/ibm-tpm2-simulator-mirror "$installation_dir"
 fi
 
 pushd $installation_dir 
 
-pushd ./tpm
 make
-popd
-
-pushd ./tss
-pushd ./utils/
-make
-popd
-popd
 
 popd

--- a/.travis/run-ibm-tpm2.sh
+++ b/.travis/run-ibm-tpm2.sh
@@ -13,6 +13,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License
 
+set -e
+
 if [[ $# -ne 1 ]]; then
         echo "usage: $0 <absolute-path-to-tpm-simulator-installation-directory>"
         exit 1
@@ -20,18 +22,10 @@ fi
 
 installation_dir="$1"
 
-pkill tpm_server
+pkill tpm_server || true
 
 pushd $installation_dir
 
-pushd tpm
-./tpm_server -rm &
-sleep 2
-popd
-
-pushd tss/utils/
-./powerup
-./startup
-popd
+./simulator.sh start
 
 popd

--- a/include/tss2/tss2_common.h
+++ b/include/tss2/tss2_common.h
@@ -147,6 +147,9 @@ typedef uint32_t TSS2_RC;
 // TPM errors
 #define TSS2_TPM_RC_LEVEL 0
 
+#define RC_WARN 0x900
+#define TPM_RC_RETRY RC_WARN + 0x022
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/create_load_evict-test.c
+++ b/test/create_load_evict-test.c
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -115,29 +115,17 @@ void full_test(const char* pub_key_filename, const char* handle_filename)
     struct test_context ctx;
     initialize(&ctx);
 
-    int ret = 0;
+    RETRY_FOR_SUCCESS(clear(&ctx));
 
-    ret = clear(&ctx);
+    RETRY_FOR_SUCCESS(create_primary(&ctx));
 
-    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+    RETRY_FOR_SUCCESS(create(&ctx));
 
-    ret = create_primary(&ctx);
+    RETRY_FOR_SUCCESS(load(&ctx));
 
-    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+    RETRY_FOR_SUCCESS(evict_control(&ctx));
 
-    ret = create(&ctx);
-
-    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
-
-    ret = load(&ctx);
-
-    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
-
-    ret = evict_control(&ctx);
-
-    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
-
-    ret = save_public_key_info(&ctx, pub_key_filename, handle_filename);
+    int ret = save_public_key_info(&ctx, pub_key_filename, handle_filename);
 
     TEST_ASSERT(TSS2_RC_SUCCESS == ret);
 

--- a/test/test-utils.h
+++ b/test/test-utils.h
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -56,3 +56,13 @@ char *handle_filename_g = "handle.txt";
         } \
         printf("Saving public key to %s and handle to %s\n", pub_key_filename_g, handle_filename_g);\
     } while(0)
+
+#define RETRY_FOR_SUCCESS(op) \
+    {   \
+        int ret;    \
+        do {    \
+            ret = op;   \
+        } while (ret == TPM_RC_RETRY);    \
+        TEST_ASSERT(TSS2_RC_SUCCESS == ret); \
+    }
+


### PR DESCRIPTION
Because one of our tests, create-load-evict-test, started intermittently failing against the new simulator, due to a return of `TPM_RC_RETRY`, this series also adds that return code to the public API. This return code is defined in the spec as being returned if there wasn't an error but the caller needs to retry the call.