### PR TITLE
Get NVRAM sizes dynamically from the TPM

### DIFF
--- a/include/tss2/tss2_sys.h
+++ b/include/tss2/tss2_sys.h
@@ -149,6 +149,14 @@ Tss2_Sys_NV_Read(TSS2_SYS_CONTEXT *sysContext,
                  TSS2_SYS_RSP_AUTHS *rspAuthsArray);
 
 TSS2_RC
+Tss2_Sys_NV_ReadPublic(TSS2_SYS_CONTEXT *sysContext,
+                       TPMI_RH_NV_INDEX nvIndex,
+                       const TSS2_SYS_CMD_AUTHS  *cmdAuthsArray,
+                       TPM2B_NV_PUBLIC *nvPublic,
+                       TPM2B_NAME *nvName,
+                       TSS2_SYS_RSP_AUTHS *rspAuthsArray);
+
+TSS2_RC
 Tss2_Sys_NV_UndefineSpace(TSS2_SYS_CONTEXT *sysContext,
                           TPMI_RH_PROVISION authHandle,
                           TPMI_RH_NV_INDEX nvIndex,

--- a/include/tss2/tss2_tpm2_types.h
+++ b/include/tss2/tss2_tpm2_types.h
@@ -60,6 +60,7 @@ typedef uint32_t TPM_CC;
 #define TPM_CC_Create 0x00000153
 #define TPM_CC_Load 0x00000157
 #define TPM_CC_Sign 0x0000015D
+#define TPM_CC_NV_ReadPublic 0x00000169
 #define TPM_CC_GetCapability 0x0000017A
 #define TPM_CC_Commit 0x0000018B
 #define TPM_CC_EvictControl 0x00000120

--- a/include/xaptum/tpm/nvram.h
+++ b/include/xaptum/tpm/nvram.h
@@ -29,44 +29,37 @@ extern "C" {
 #define XTPM_GPK_LENGTH              258
 #define XTPM_CRED_LENGTH             260
 #define XTPM_CRED_SIG_LENGTH         64
-#define XTPM_ROOT_ID_LENGTH          16
-#define XTPM_ROOT_PUBKEY_LENGTH      65
 #define XTPM_SERVER_ID_LENGTH        16
 
 uint16_t xtpm_gpk_length();
 uint16_t xtpm_cred_length();
 uint16_t xtpm_cred_sig_length();
-uint16_t xtpm_root_id_length();
-uint16_t xtpm_root_pubkey_length();
 uint16_t xtpm_server_id_length();
 
 #define XTPM_GPK_HANDLE             0x1410000
 #define XTPM_CRED_HANDLE            0x1410001
 #define XTPM_CRED_SIG_HANDLE        0x1410002
-#define XTPM_ROOT_ID_HANDLE         0x1410003
-#define XTPM_ROOT_PUBKEY_HANDLE     0x1410004
 #define XTPM_ROOT_ASN1CERT_HANDLE   0x1410005
 #define XTPM_BASENAME_HANDLE        0x1410007
 #define XTPM_SERVER_ID_HANDLE       0x1410008
+#define XTPM_ROOT_XTTCERT_HANDLE    0x1410009
 
 TPMI_RH_NV_INDEX xtpm_gpk_handle();
 TPMI_RH_NV_INDEX xtpm_cred_handle();
 TPMI_RH_NV_INDEX xtpm_cred_sig_handle();
-TPMI_RH_NV_INDEX xtpm_root_id_handle();
-TPMI_RH_NV_INDEX xtpm_root_pubkey_handle();
 TPMI_RH_NV_INDEX xtpm_root_asn1cert_handle();
 TPMI_RH_NV_INDEX xtpm_basename_handle();
 TPMI_RH_NV_INDEX xtpm_serverid_handle();
+TPMI_RH_NV_INDEX xtpm_root_xttcert_handle();
 
 enum xtpm_object_name {
     XTPM_GROUP_PUBLIC_KEY,
     XTPM_CREDENTIAL,
     XTPM_CREDENTIAL_SIGNATURE,
-    XTPM_ROOT_ID,
-    XTPM_ROOT_PUBKEY,
     XTPM_ROOT_ASN1_CERTIFICATE,
     XTPM_BASENAME,
     XTPM_SERVER_ID,
+    XTPM_ROOT_XTT_CERTIFICATE,
 };
 
 TSS2_RC

--- a/include/xaptum/tpm/nvram.h
+++ b/include/xaptum/tpm/nvram.h
@@ -31,8 +31,6 @@ extern "C" {
 #define XTPM_CRED_SIG_LENGTH         64
 #define XTPM_ROOT_ID_LENGTH          16
 #define XTPM_ROOT_PUBKEY_LENGTH      65
-#define XTPM_ROOT_ASN1CERT_LENGTH    579
-#define XTPM_BASENAME_LENGTH         0  // size must be read from previous index
 #define XTPM_SERVER_ID_LENGTH        16
 
 uint16_t xtpm_gpk_length();
@@ -40,8 +38,6 @@ uint16_t xtpm_cred_length();
 uint16_t xtpm_cred_sig_length();
 uint16_t xtpm_root_id_length();
 uint16_t xtpm_root_pubkey_length();
-uint16_t xtpm_root_asn1cert_length();
-uint16_t xtpm_basename_length();
 uint16_t xtpm_server_id_length();
 
 #define XTPM_GPK_HANDLE             0x1410000
@@ -50,7 +46,6 @@ uint16_t xtpm_server_id_length();
 #define XTPM_ROOT_ID_HANDLE         0x1410003
 #define XTPM_ROOT_PUBKEY_HANDLE     0x1410004
 #define XTPM_ROOT_ASN1CERT_HANDLE   0x1410005
-#define XTPM_BASENAME_SIZE_HANDLE   0x1410006
 #define XTPM_BASENAME_HANDLE        0x1410007
 #define XTPM_SERVER_ID_HANDLE       0x1410008
 
@@ -87,6 +82,10 @@ xtpm_read_nvram(unsigned char *out,
                 TPM_HANDLE index,
                 TSS2_SYS_CONTEXT *sapi_context);
 
+TSS2_RC
+xtpm_get_nvram_size(uint16_t *size_out,
+                    TPM_HANDLE index,
+                    TSS2_SYS_CONTEXT *sapi_context);
 
 #ifdef __cplusplus
 }

--- a/include/xaptum/tpm/nvram.h
+++ b/include/xaptum/tpm/nvram.h
@@ -26,16 +26,6 @@
 extern "C" {
 #endif
 
-#define XTPM_GPK_LENGTH              258
-#define XTPM_CRED_LENGTH             260
-#define XTPM_CRED_SIG_LENGTH         64
-#define XTPM_SERVER_ID_LENGTH        16
-
-uint16_t xtpm_gpk_length();
-uint16_t xtpm_cred_length();
-uint16_t xtpm_cred_sig_length();
-uint16_t xtpm_server_id_length();
-
 #define XTPM_GPK_HANDLE             0x1410000
 #define XTPM_CRED_HANDLE            0x1410001
 #define XTPM_CRED_SIG_HANDLE        0x1410002

--- a/src/internal/marshal.c
+++ b/src/internal/marshal.c
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -186,7 +186,7 @@ int unmarshal_tpm2b_simple(uint8_t **in, uint32_t *in_max_length, TPM2B_SIMPLE *
 {
     if (0 != unmarshal_uint16(in, in_max_length, &out->size))
         return -1;
-    
+
     if (*in_max_length < out->size)
         return -1;
     memcpy(out->buffer, *in, out->size);
@@ -459,19 +459,19 @@ int unmarshal_tpma_session(uint8_t **in, uint32_t *in_max_length, TPMA_SESSION *
 
     memset(out, 0, sizeof(TPMA_SESSION));  // clear all
 
-    if ((*in[0]) & BIT_ZERO)
+    if (((*in)[0]) & BIT_ZERO)
         out->continueSession = 1;
-    if ((*in[0]) & BIT_ONE)
+    if (((*in)[0]) & BIT_ONE)
         out->auditExclusive = 1;
-    if ((*in[0]) & BIT_TWO)
+    if (((*in)[0]) & BIT_TWO)
         out->auditReset = 1;
     // bit three is reserved
     // bit four is reserved
-    if ((*in[0]) & BIT_FIVE)
+    if (((*in)[0]) & BIT_FIVE)
         out->decrypt = 1;
-    if ((*in[0]) & BIT_SIX)
+    if (((*in)[0]) & BIT_SIX)
         out->encrypt = 1;
-    if ((*in[0]) & BIT_SEVEN)
+    if (((*in)[0]) & BIT_SEVEN)
         out->audit = 1;
 
     *in += 1;
@@ -524,7 +524,7 @@ int unmarshal_tpm2b_creationdata(uint8_t **in, uint32_t *in_max_length, TPM2B_CR
         return -1;
     if (*in_max_length < out->size)
         return -1;
-    
+
     if (0 != unmarshal_tpml_pcrselection(in, in_max_length, &out->creationData.pcrSelect))
         return -1;
 
@@ -542,7 +542,7 @@ int unmarshal_tpm2b_creationdata(uint8_t **in, uint32_t *in_max_length, TPM2B_CR
 
     if (0 != unmarshal_tpm2b_name(in, in_max_length, &out->creationData.parentName))
         return -1;
-    
+
     if (0 != unmarshal_tpm2b_name(in, in_max_length, &out->creationData.parentQualifiedName))
         return -1;
 
@@ -751,6 +751,76 @@ void marshal_tpmanv(const TPMA_NV *in, uint8_t **out)
     *out += 4;
 }
 
+int unmarshal_tpmanv(uint8_t **in, uint32_t *in_max_length, TPMA_NV *out)
+{
+    if (*in_max_length < 4)
+        return -1;
+
+    memset(out, 0, sizeof(TPMA_NV));  // clear all
+
+    if (((*in)[3]) & BIT_ZERO)
+        out->TPMA_NV_PPWRITE = 1;
+    if (((*in)[3]) & BIT_ONE)
+        out->TPMA_NV_OWNERWRITE = 1;
+    if (((*in)[3]) & BIT_TWO)
+        out->TPMA_NV_AUTHWRITE = 1;
+    if (((*in)[3]) & BIT_THREE)
+        out->TPMA_NV_POLICYWRITE = 1;
+    if (((*in)[3]) & BIT_FOUR)
+        out->TPMA_NV_COUNTER = 1;
+    if (((*in)[3]) & BIT_FIVE)
+        out->TPMA_NV_BITS = 1;
+    if (((*in)[3]) & BIT_SIX)
+        out->TPMA_NV_EXTEND = 1;
+    // bit 7 is reserved
+    // bit 8 is reserved
+    // bit 9 is reserved
+    if (((*in)[2]) & BIT_TWO)
+        out->TPMA_NV_POLICY_DELETE = 1;
+    if (((*in)[2]) & BIT_THREE)
+        out->TPMA_NV_WRITELOCKED = 1;
+    if (((*in)[2]) & BIT_FOUR)
+        out->TPMA_NV_WRITEALL = 1;
+    if (((*in)[2]) & BIT_FIVE)
+        out->TPMA_NV_WRITEDEFINE = 1;
+    if (((*in)[2]) & BIT_SIX)
+        out->TPMA_NV_WRITE_STCLEAR = 1;
+    if (((*in)[2]) & BIT_SEVEN)
+        out->TPMA_NV_GLOBALLOCK = 1;
+    if (((*in)[1]) & BIT_ZERO)
+        out->TPMA_NV_PPREAD = 1;
+    if (((*in)[1]) & BIT_ONE)
+        out->TPMA_NV_OWNERREAD = 1;
+    if (((*in)[1]) & BIT_TWO)
+        out->TPMA_NV_AUTHREAD = 1;
+    if (((*in)[1]) & BIT_THREE)
+        out->TPMA_NV_POLICYREAD = 1;
+    // bit 20 is reserved
+    // bit 21 is reserved
+    // bit 22 is reserved
+    // bit 23 is reserved
+    // bit 24 is reserved
+    if (((*in)[0]) & BIT_ONE)
+        out->TPMA_NV_NO_DA = 1;
+    if (((*in)[0]) & BIT_TWO)
+        out->TPMA_NV_ORDERLY = 1;
+    if (((*in)[0]) & BIT_THREE)
+        out->TPMA_NV_CLEAR_STCLEAR = 1;
+    if (((*in)[0]) & BIT_FOUR)
+        out->TPMA_NV_READLOCKED = 1;
+    if (((*in)[0]) & BIT_FIVE)
+        out->TPMA_NV_WRITTEN = 1;
+    if (((*in)[0]) & BIT_SIX)
+        out->TPMA_NV_PLATFORMCREATE = 1;
+    if (((*in)[0]) & BIT_SEVEN)
+        out->TPMA_NV_READ_STCLEAR = 1;
+
+    *in += 4;
+    *in_max_length -= 4;
+
+    return 0;
+}
+
 void marshal_tpm2b_nvpublic(const TPM2B_NV_PUBLIC *in, uint8_t **out)
 {
     uint8_t *size_ptr = *out;
@@ -768,6 +838,31 @@ void marshal_tpm2b_nvpublic(const TPM2B_NV_PUBLIC *in, uint8_t **out)
 
     uint16_t size = *out - size_ptr - sizeof(uint16_t);
     marshal_uint16(size, &size_ptr);
+}
+
+int unmarshal_tpm2b_nvpublic(uint8_t **in, uint32_t *in_max_length, TPM2B_NV_PUBLIC *out)
+{
+    if (0 != unmarshal_uint16(in, in_max_length, &out->size))
+        return -1;
+    if (*in_max_length < out->size)
+        return -1;
+
+    if (0 != unmarshal_uint32(in, in_max_length, &out->nvPublic.nvIndex))
+        return -1;
+
+    if (0 != unmarshal_tpmi_alg_id(in, in_max_length, &out->nvPublic.nameAlg))
+        return -1;
+
+    if (0 != unmarshal_tpmanv(in, in_max_length, &out->nvPublic.attributes))
+        return -1;
+
+    if (0 != unmarshal_tpm2b_digest(in, in_max_length, &out->nvPublic.authPolicy))
+        return -1;
+
+    if (0 != unmarshal_uint16(in, in_max_length, &out->nvPublic.dataSize))
+        return -1;
+
+    return 0;
 }
 
 void marshal_tpm2b_maxnvbuffer(const TPM2B_MAX_NV_BUFFER *in, uint8_t **out)

--- a/src/internal/marshal.h
+++ b/src/internal/marshal.h
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -76,6 +76,8 @@ int unmarshal_tpmt_signature(uint8_t **in, uint32_t *in_max_length, TPMT_SIGNATU
 void marshal_tpm2b_auth(const TPM2B_AUTH *in, uint8_t **out);
 
 void marshal_tpm2b_nvpublic(const TPM2B_NV_PUBLIC *in, uint8_t **out);
+
+int unmarshal_tpm2b_nvpublic(uint8_t **in, uint32_t *in_max_length, TPM2B_NV_PUBLIC *out);
 
 void marshal_tpm2b_maxnvbuffer(const TPM2B_MAX_NV_BUFFER *in, uint8_t **out);
 

--- a/src/xaptum/nvram.c
+++ b/src/xaptum/nvram.c
@@ -37,16 +37,6 @@ uint16_t xtpm_cred_sig_length()
     return XTPM_CRED_SIG_LENGTH;
 }
 
-uint16_t xtpm_root_id_length()
-{
-    return XTPM_ROOT_ID_LENGTH;
-}
-
-uint16_t xtpm_root_pubkey_length()
-{
-    return XTPM_ROOT_PUBKEY_LENGTH;
-}
-
 TPMI_RH_NV_INDEX xtpm_gpk_handle()
 {
     return XTPM_GPK_HANDLE;
@@ -62,19 +52,14 @@ TPMI_RH_NV_INDEX xtpm_cred_sig_handle()
     return XTPM_CRED_SIG_HANDLE;
 }
 
-TPMI_RH_NV_INDEX xtpm_root_id_handle()
-{
-    return XTPM_ROOT_ID_HANDLE;
-}
-
-TPMI_RH_NV_INDEX xtpm_root_pubkey_handle()
-{
-    return XTPM_ROOT_PUBKEY_HANDLE;
-}
-
 TPMI_RH_NV_INDEX xtpm_root_asn1cert_handle()
 {
     return XTPM_ROOT_ASN1CERT_HANDLE;
+}
+
+TPMI_RH_NV_INDEX xtpm_root_xttcert_handle()
+{
+    return XTPM_ROOT_XTTCERT_HANDLE;
 }
 
 TSS2_RC
@@ -100,14 +85,6 @@ xtpm_read_object(unsigned char* out_buffer,
             index = XTPM_CRED_SIG_HANDLE;
             size = XTPM_CRED_SIG_LENGTH;
             break;
-        case XTPM_ROOT_ID:
-            index = XTPM_ROOT_ID_HANDLE;
-            size = XTPM_ROOT_ID_LENGTH;
-            break;
-        case XTPM_ROOT_PUBKEY:
-            index = XTPM_ROOT_PUBKEY_HANDLE;
-            size = XTPM_ROOT_PUBKEY_LENGTH;
-            break;
         case XTPM_ROOT_ASN1_CERTIFICATE:
             {
             index = XTPM_ROOT_ASN1CERT_HANDLE;
@@ -128,6 +105,14 @@ xtpm_read_object(unsigned char* out_buffer,
             index = XTPM_SERVER_ID_HANDLE;
             size = XTPM_SERVER_ID_LENGTH;
             break;
+        case XTPM_ROOT_XTT_CERTIFICATE:
+            {
+            index = XTPM_ROOT_XTTCERT_HANDLE;
+            TSS2_RC ret = xtpm_get_nvram_size(&size, index, sapi_context);
+            if (TSS2_RC_SUCCESS != ret)
+                return ret;
+            break;
+            }
     }
 
     if (out_buffer_size < size)

--- a/src/xaptum/nvram.c
+++ b/src/xaptum/nvram.c
@@ -22,21 +22,6 @@
 
 #include <string.h>
 
-uint16_t xtpm_gpk_length()
-{
-    return XTPM_GPK_LENGTH;
-}
-
-uint16_t xtpm_cred_length()
-{
-    return XTPM_CRED_LENGTH;
-}
-
-uint16_t xtpm_cred_sig_length()
-{
-    return XTPM_CRED_SIG_LENGTH;
-}
-
 TPMI_RH_NV_INDEX xtpm_gpk_handle()
 {
     return XTPM_GPK_HANDLE;
@@ -57,6 +42,11 @@ TPMI_RH_NV_INDEX xtpm_root_asn1cert_handle()
     return XTPM_ROOT_ASN1CERT_HANDLE;
 }
 
+TPMI_RH_NV_INDEX xtpm_serverid_handle()
+{
+    return XTPM_SERVER_ID_HANDLE;
+}
+
 TPMI_RH_NV_INDEX xtpm_root_xttcert_handle()
 {
     return XTPM_ROOT_XTTCERT_HANDLE;
@@ -69,51 +59,36 @@ xtpm_read_object(unsigned char* out_buffer,
                  enum xtpm_object_name object_name,
                  TSS2_SYS_CONTEXT *sapi_context)
 {
-    uint16_t size = 0;
     TPM_HANDLE index = 0;
 
     switch (object_name) {
         case XTPM_GROUP_PUBLIC_KEY:
             index = XTPM_GPK_HANDLE;
-            size = XTPM_GPK_LENGTH;
             break;
         case XTPM_CREDENTIAL:
             index = XTPM_CRED_HANDLE;
-            size = XTPM_CRED_LENGTH;
             break;
         case XTPM_CREDENTIAL_SIGNATURE:
             index = XTPM_CRED_SIG_HANDLE;
-            size = XTPM_CRED_SIG_LENGTH;
             break;
         case XTPM_ROOT_ASN1_CERTIFICATE:
-            {
             index = XTPM_ROOT_ASN1CERT_HANDLE;
-            TSS2_RC ret = xtpm_get_nvram_size(&size, index, sapi_context);
-            if (TSS2_RC_SUCCESS != ret)
-                return ret;
             break;
-            }
         case XTPM_BASENAME:
-            {
             index = XTPM_BASENAME_HANDLE;
-            TSS2_RC ret = xtpm_get_nvram_size(&size, index, sapi_context);
-            if (TSS2_RC_SUCCESS != ret)
-                return ret;
             break;
-            }
         case XTPM_SERVER_ID:
             index = XTPM_SERVER_ID_HANDLE;
-            size = XTPM_SERVER_ID_LENGTH;
             break;
         case XTPM_ROOT_XTT_CERTIFICATE:
-            {
             index = XTPM_ROOT_XTTCERT_HANDLE;
-            TSS2_RC ret = xtpm_get_nvram_size(&size, index, sapi_context);
-            if (TSS2_RC_SUCCESS != ret)
-                return ret;
             break;
-            }
     }
+
+    uint16_t size = 0;
+    TSS2_RC ret = xtpm_get_nvram_size(&size, index, sapi_context);
+    if (TSS2_RC_SUCCESS != ret)
+        return ret;
 
     if (out_buffer_size < size)
         return TSS2_BASE_RC_INSUFFICIENT_BUFFER;

--- a/util/xtpm_read_nvram.c
+++ b/util/xtpm_read_nvram.c
@@ -175,7 +175,7 @@ parse_cli_args(int argc,
         "\t\t-p --tpm-port          TCP port of TPM TCP server, if tcti==socket [default: 2321].\n"
         "\t\t-o --output-file       Output file. [default: '<object-name>.bin' or 'root.cert.asn1.bin']\n"
         "\tArguments:\n"
-        "\t\tobject-name\tOne of gpk, cred, cred_sig, root_id, root_pubkey, root_asn1_cert, basename, or server_id\n"
+        "\t\tobject-name\tOne of gpk, cred, cred_sig, root_asn1_cert, root_xtt_cert, basename, or server_id\n"
         ;
 
     ctx->tcti = TCTI_DEVICE;
@@ -238,18 +238,14 @@ parse_cli_args(int argc,
             ctx->obj_name = XTPM_CREDENTIAL_SIGNATURE;
             if (ctx->out_filename == NULL)
                 ctx->out_filename = "cred_sig.bin";
-        } else if (0 == strcmp(argv[optind], "root_id")) {
-            ctx->obj_name = XTPM_ROOT_ID;
-            if (ctx->out_filename == NULL)
-                ctx->out_filename = "root_id.bin";
-        } else if (0 == strcmp(argv[optind], "root_pubkey")) {
-            ctx->obj_name = XTPM_ROOT_PUBKEY;
-            if (ctx->out_filename == NULL)
-                ctx->out_filename = "root_pubkey.bin";
         } else if (0 == strcmp(argv[optind], "root_asn1_cert")) {
             ctx->obj_name = XTPM_ROOT_ASN1_CERTIFICATE;
             if (ctx->out_filename == NULL)
                 ctx->out_filename = "root.cert.asn1.pem";
+        } else if (0 == strcmp(argv[optind], "root_xtt_cert")) {
+            ctx->obj_name = XTPM_ROOT_XTT_CERTIFICATE;
+            if (ctx->out_filename == NULL)
+                ctx->out_filename = "root_xtt_cert.bin";
         } else if (0 == strcmp(argv[optind], "basename")) {
             ctx->obj_name = XTPM_BASENAME;
             if (ctx->out_filename == NULL)


### PR DESCRIPTION
This series
- Adds the `TSS2_ReadPublic` command, for accessing the public data of an already-defined NVRAM index
- Uses `ReadPublic` to allow variable-length NVRAM reads in the `xaptum/nvram` utility (i.e. the basename and the root ASN.1 certificate) (fixes #47)
- Also converts the other NVRAM reads that are constant-length to the same query-size-then-read-value scheme, so that the sizes don't have to be hardcoded in this project
- Reads the root's public key and ID as a single NVRAM index (fixes #48)