### PR TITLE
test: Don't compare length of signature.R to that of digest.

### DIFF
--- a/test/tss2_sys_sign-test.c
+++ b/test/tss2_sys_sign-test.c
@@ -276,8 +276,7 @@ void full_test()
 
     TEST_ASSERT(TSS2_RC_SUCCESS == ret);
 
-    TEST_ASSERT(digest.size != 0);
-    TEST_ASSERT(digest.size == signature.signature.ecdaa.signatureR.size);
+    TEST_ASSERT(signature.signature.ecdaa.signatureR.size != 0);
 
     TEST_ASSERT(signature.signature.ecdaa.signatureS.size != 0);
     uint8_t zeroes[64];


### PR DESCRIPTION
The r value is now a nonce, not a hash, so sometimes it's shorter than a
hash length.

This is related to the earlier changes regarding the new TPMs and the new TPM spec.