### PR TITLE
travis: Add a test of the installation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_script:
 script:
   - pushd ${XTPM_BUILD_DIR}
   - cmake --build . --target install -- -j2
+  - ${TRAVIS_BUILD_DIR}/.travis/build-against-installed.sh ${XTPM_INSTALL_DIR} ${TRAVIS_BUILD_DIR}
   - ${TRAVIS_BUILD_DIR}/.travis/run-ibm-tpm2.sh ${IBM_TPM_DIR}
   - ctest -VV
   - popd

--- a/.travis/build-against-installed.sh
+++ b/.travis/build-against-installed.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Attempt to build a project that depends on xaptum-tpm,
+# to test that an installation of xaptum-tpm works correctly.
+
+set -e
+
+if [[ $# -ne 2 ]]; then
+        echo "usage: $0 <xaptum-tpm installation directory> <tmp directory>"
+        exit 1
+fi
+
+install_dir="$1"
+tmp_dir="$2"
+output_file=${tmp_dir}/installation-test.out
+
+function cleanup()
+{
+        rm -f $output_file
+}
+trap cleanup INT KILL EXIT
+
+LIB_DIR="${install_dir}/lib"
+
+INCLUDE_FLAGS="-I${install_dir}/include"
+LINKER_FLAGS="-L${LIB_DIR} -lxaptum-tpm"
+
+echo "Attempting to build downstream program..."
+cc $INCLUDE_FLAGS -x c - -o $output_file -std=c99 $LINKER_FLAGS <<'EOF'
+#include <stdio.h>
+#include <tss2/tss2_common.h>
+#include <tss2/tss2_sys.h>
+#include <tss2/tss2_tcti.h>
+#include <tss2/tss2_tcti_device.h>
+#include <tss2/tss2_tcti_socket.h>
+#include <tss2/tss2_tpm2_types.h>
+int main() {
+printf("It worked!\n");
+}
+EOF
+echo "ok"
+
+echo "Attempting to run downstream executable..."
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${LIB_DIR}
+${output_file}
+echo "ok"


### PR DESCRIPTION
After building and installing locally, run a test script that attempts
to build a small program that includes xaptum-tpm headers.
This is to check that the installation of xaptum-tpm headers and libs
works OK.