### PR TITLE
travis: Use new ibm tpm simulator and tss.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   - XTPM_BUILD_DIR=${TRAVIS_BUILD_DIR}/build
   - XTPM_INSTALL_DIR=${TRAVIS_BUILD_DIR}/install
   - IBM_TPM_DIR=${TRAVIS_BUILD_DIR}/ibm-tpm-simulator
-  - IBM_TPM_TAG=1332
+  - IBM_TPM_TAG=1637
   - SHARED_LIBS=ON
 
 before_script:


### PR DESCRIPTION
The old version we were using appears to have some bug where the first usage of a primary key fails, but only when ordered in some particular way.
The old ordering of our tests didn't run into this, but the new reorganization work (PR #54 ) caused a reordering of the tests and consistently tripped this. When our tests were run for the first time on a just-started simulator, the first test to use a primary key would fail, but all subsequent tests would succeed. Further, running all the tests again (against the same simulator, i.e. not restarting the simulator) resulted in all tests succeeding.

The issue doesn't appear to be with our library, as I was able to trigger it using the tpm2-software TSS stack as well as with the pre-reorganization version of this project (by reordering the tests).

Updating to the newest IBM simulator version appears to fix it.