### PR TITLE
tss2: Changes for ReadPublic function

### DIFF
--- a/tss2/CMakeLists.txt
+++ b/tss2/CMakeLists.txt
@@ -37,6 +37,7 @@ set(XAPTUM_TSS2_SYS_SRCS
     src/tss2_sys_hierarchychangeauth.c
     src/tss2_sys_load.c
     src/tss2_sys_evictcontrol.c
+    src/tss2_sys_readpublic.c
     src/tss2_sys_nv.c
     src/tss2_sys_sign.c
 

--- a/tss2/include/tss2/tss2_sys.h
+++ b/tss2/include/tss2/tss2_sys.h
@@ -196,6 +196,15 @@ Tss2_Sys_Clear(TSS2_SYS_CONTEXT *sysContext,
                const TSS2L_SYS_AUTH_COMMAND *cmdAuthsArray,
                TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray);
 
+TSS2_RC
+Tss2_Sys_ReadPublic(TSS2_SYS_CONTEXT *sysContext,
+                    TPMI_DH_OBJECT objectHandle,
+                    const TSS2L_SYS_AUTH_COMMAND *cmdAuthsArray,
+                    TPM2B_PUBLIC *outPublic,
+                    TPM2B_NAME *name,
+                    TPM2B_NAME *qualifiedName,
+                    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tss2/include/tss2/tss2_tpm2_types.h
+++ b/tss2/include/tss2/tss2_tpm2_types.h
@@ -64,6 +64,7 @@ typedef uint32_t TPM2_CC;
 #define TPM2_CC_Load 0x00000157
 #define TPM2_CC_Sign 0x0000015D
 #define TPM2_CC_NV_ReadPublic 0x00000169
+#define TPM2_CC_ReadPublic 0x00000173
 #define TPM2_CC_GetCapability 0x0000017A
 #define TPM2_CC_Commit 0x0000018B
 #define TPM2_CC_EvictControl 0x00000120

--- a/tss2/src/internal/cmdauths.c
+++ b/tss2/src/internal/cmdauths.c
@@ -26,10 +26,10 @@ TSS2_RC
 set_cmdauths(TSS2_SYS_CONTEXT_OPAQUE *sys_context,
              const TSS2L_SYS_AUTH_COMMAND *cmd_auths_array)
 {
-    sys_context->cmd_auths_count = cmd_auths_array->count;
-
-    if (0 == cmd_auths_array->count)
+    if (NULL == cmd_auths_array || 0 == cmd_auths_array->count)
         return TSS2_RC_SUCCESS;
+
+    sys_context->cmd_auths_count = cmd_auths_array->count;
 
     uint8_t *size_ptr = sys_context->ptr;
 
@@ -50,6 +50,9 @@ TSS2_RC
 get_rspauths(TSS2_SYS_CONTEXT_OPAQUE *sys_context,
              TSS2L_SYS_AUTH_RESPONSE *rsp_auths_array)
 {
+    if (NULL == rsp_auths_array || 0 == rsp_auths_array->count)
+        return TSS2_RC_SUCCESS;
+
     if (rsp_auths_array->count != sys_context->cmd_auths_count)
         return TSS2_SYS_RC_INVALID_SESSIONS;
 

--- a/tss2/src/tss2_sys_readpublic.c
+++ b/tss2/src/tss2_sys_readpublic.c
@@ -1,0 +1,78 @@
+/******************************************************************************
+ *
+ * Copyright 2017-2020 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include <tss2/tss2_sys.h>
+
+#include "internal/command_utils.h"
+#include "internal/sys_context_common.h"
+#include "internal/marshal.h"
+#include "internal/execute.h"
+#include "internal/cmdauths.h"
+
+#include <assert.h>
+
+TSS2_RC
+Tss2_Sys_ReadPublic(TSS2_SYS_CONTEXT *sysContext,
+                    TPMI_DH_OBJECT objectHandle,
+                    const TSS2L_SYS_AUTH_COMMAND *cmdAuthsArray,
+                    TPM2B_PUBLIC *outPublic,
+                    TPM2B_NAME *name,
+                    TPM2B_NAME *qualifiedName,
+                    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
+{
+    if (NULL == sysContext ||
+        NULL == outPublic ||
+        NULL ==  name ||
+        NULL == qualifiedName)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+
+    TSS2_SYS_CONTEXT_OPAQUE *sys_context = down_cast(sysContext);
+
+    build_command_header(sys_context, TPM2_CC_ReadPublic, TPM2_ST_NO_SESSIONS);
+
+    marshal_uint32(objectHandle, &sys_context->ptr);
+
+    ret = set_cmdauths(sys_context, cmdAuthsArray);
+    if (TSS2_RC_SUCCESS != ret)
+        return ret;
+
+    set_command_size(sys_context);
+
+    ret = Tss2_Sys_Execute(sys_context);
+    if (ret)
+        return ret;
+
+    ret = get_rspauths(sys_context, rspAuthsArray);
+    if (ret)
+        return ret;
+
+    if (0 != unmarshal_tpm2b_public(&sys_context->ptr, &sys_context->remaining_response, outPublic))
+        return TSS2_SYS_RC_MALFORMED_RESPONSE;
+
+    if (0 != unmarshal_tpm2b_name(&sys_context->ptr, &sys_context->remaining_response, name))
+        return TSS2_SYS_RC_MALFORMED_RESPONSE;
+
+    if (0 != unmarshal_tpm2b_name(&sys_context->ptr, &sys_context->remaining_response, qualifiedName))
+        return TSS2_SYS_RC_MALFORMED_RESPONSE;
+
+    assert(sys_context->remaining_response == 0);
+
+    return ret;
+}

--- a/tss2/test/tss2_sys_readpublic-test.c
+++ b/tss2/test/tss2_sys_readpublic-test.c
@@ -1,0 +1,172 @@
+/******************************************************************************
+ *
+ * Copyright 2020 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include "test-utils.h"
+
+const TPMA_OBJECT obj_attrs = TPMA_OBJECT_FIXEDTPM | TPMA_OBJECT_FIXEDPARENT | TPMA_OBJECT_SENSITIVEDATAORIGIN | TPMA_OBJECT_USERWITHAUTH | TPMA_OBJECT_SIGN_ENCRYPT;
+
+struct test_context {
+    TSS2_SYS_CONTEXT *sapi_ctx;
+    TPM2_HANDLE key_handle;
+    TPM2_HANDLE persistent_key_handle;
+};
+
+static void initialize(struct test_context *ctx);
+static void cleanup(struct test_context *ctx);
+static int clear(struct test_context *ctx);
+static int createprimary(struct test_context *ctx);
+
+static void full_test();
+
+int main(int argc, char *argv[])
+{
+    parse_cmd_args(argc, argv);
+
+    full_test();
+}
+
+void initialize(struct test_context *ctx)
+{
+    init_sapi(&ctx->sapi_ctx);
+
+    TEST_ASSERT(0 == createprimary(ctx));
+}
+
+void cleanup(struct test_context *ctx)
+{
+    TSS2_TCTI_CONTEXT *tcti_context = NULL;
+
+    if (ctx->sapi_ctx != NULL) {
+        TSS2_RC rc = Tss2_Sys_GetTctiContext(ctx->sapi_ctx, &tcti_context);
+        TEST_ASSERT(TSS2_RC_SUCCESS == rc);
+
+        Tss2_Tcti_Finalize(tcti_context);
+        free(tcti_context);
+
+        Tss2_Sys_Finalize(ctx->sapi_ctx);
+        free(ctx->sapi_ctx);
+    }
+}
+
+int createprimary(struct test_context *ctx)
+{
+    printf("In tss2_sys_createprimary-test::full_test...\n");
+
+    TEST_ASSERT(0 == clear(ctx));
+
+    TPMI_RH_HIERARCHY hierarchy = TPM2_RH_OWNER;
+
+    TSS2L_SYS_AUTH_COMMAND sessionsData = EMPTY_AUTH_COMMAND;
+
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut = {.count = 1};
+
+    TPM2B_SENSITIVE_CREATE inSensitive = {};
+
+    TPM2B_PUBLIC in_public = {.publicArea = {.type=TPM2_ALG_ECC,
+                                             .nameAlg=TPM2_ALG_SHA256,
+                                             .objectAttributes=obj_attrs}};
+    in_public.publicArea.parameters.eccDetail.symmetric.algorithm = TPM2_ALG_NULL;
+    in_public.publicArea.parameters.eccDetail.scheme.scheme = TPM2_ALG_ECDAA;
+    in_public.publicArea.parameters.eccDetail.scheme.details.ecdaa.hashAlg = TPM2_ALG_SHA256;
+    in_public.publicArea.parameters.eccDetail.scheme.details.ecdaa.count = 1;
+    in_public.publicArea.parameters.eccDetail.curveID = TPM2_ECC_BN_P256;
+    in_public.publicArea.parameters.eccDetail.kdf.scheme = TPM2_ALG_NULL;
+    in_public.publicArea.unique.ecc.x.size = 0;
+    in_public.publicArea.unique.ecc.y.size = 0;
+
+    TPM2B_DATA outsideInfo = {};
+
+    TPML_PCR_SELECTION creationPCR = {};
+
+    TPM2B_CREATION_DATA creationData = {};
+    TPM2B_DIGEST creationHash = {};
+    TPMT_TK_CREATION creationTicket = {};
+
+    TPM2B_NAME name = {};
+
+    TPM2B_PUBLIC public_key;
+
+    TSS2_RC ret = Tss2_Sys_CreatePrimary(ctx->sapi_ctx,
+                                         hierarchy,
+                                         &sessionsData,
+                                         &inSensitive,
+                                         &in_public,
+                                         &outsideInfo,
+                                         &creationPCR,
+                                         &ctx->key_handle,
+                                         &public_key,
+                                         &creationData,
+                                         &creationHash,
+                                         &creationTicket,
+                                         &name,
+                                         &sessionsDataOut);
+
+    if (TSS2_RC_SUCCESS != ret)
+        return -1;
+
+    return 0;
+}
+
+void full_test()
+{
+    printf("In tss2_sys_readpublic-test::full_test...\n");
+
+    struct test_context ctx;
+    initialize(&ctx);
+
+    TPM2B_PUBLIC public_key_out = {};
+
+    TPM2B_NAME name = {};
+    TPM2B_NAME qualified_name = {};
+
+    TSS2_RC ret = Tss2_Sys_ReadPublic(ctx.sapi_ctx,
+                                      ctx.key_handle,
+                                      NULL,
+                                      &public_key_out,
+                                      &name,
+                                      &qualified_name,
+                                      NULL);
+
+    cleanup(&ctx);
+
+    printf("Readpublic ret = %#X\n", ret);
+    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+
+    TEST_ASSERT(public_key_out.publicArea.objectAttributes == obj_attrs);
+
+    printf("ok\n");
+}
+
+int clear(struct test_context *ctx)
+{
+   TPMI_RH_CLEAR auth_handle = TPM2_RH_LOCKOUT;
+
+   TSS2L_SYS_AUTH_COMMAND sessionsData = EMPTY_AUTH_COMMAND;
+
+   TSS2L_SYS_AUTH_RESPONSE sessionsDataOut = {.count = 1};
+
+   TSS2_RC ret = Tss2_Sys_Clear(ctx->sapi_ctx,
+                                auth_handle,
+                                &sessionsData,
+                                &sessionsDataOut);
+
+   printf("Clear ret=%#X\n", ret);
+
+   return ret;
+}
+


### PR DESCRIPTION
This PR updates the `tss2` sub-project to add the `ReadPublic` TSS function, for accessing the public attributes of a loaded key. This will be necessary for the upcoming work for generating keys (this function will allow us to ensure a correct parent key is available).

This includes:
- Adding the `Tss2_Sys_ReadPublic` function
- Allowing `NULL` to be specified for the "command authorizations" for functions that don't require authorization (e.g. `ReadPublic`)
  - This matches the `tpm2-software` TSS behavior