### PR TITLE
Add `keys` functionality (for key generation, saving, and signing).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,14 @@ set(XAPTUM_TPM_VERSION ${PROJECT_VERSION})
 set(XAPTUM_TPM_SOVERSION ${PROJECT_VERSION_MAJOR})
 
 set(XAPTUM_TPM_SRCS
+  src/keys.c
   src/nvram.c
+
+  src/internal/asn1.c
+  src/internal/keys-impl.c
+  src/internal/marshal.c
+  src/internal/pem.c
+  src/internal/sapi.c
 ) 
 
 ################################################################################

--- a/include/xaptum-tpm/keys.h
+++ b/include/xaptum-tpm/keys.h
@@ -1,0 +1,121 @@
+/******************************************************************************
+ *
+ * Copyright 2020 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#ifndef XAPTUM_TPM_KEYS_H
+#define XAPTUM_TPM_KEYS_H
+#pragma once
+
+#include <tss2/tss2_tcti.h>
+#include <tss2/tss2_sys.h>
+
+#define XTPM_PUB_KEY_SIZE 65
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Child key information.
+ *
+ * NOTE: The parent and child keys are assumed to have *no auth* set.
+ */
+struct xtpm_key {
+    TPM2_HANDLE parent_handle;
+    TPM2B_PUBLIC public_key;
+    TPM2B_PRIVATE private_key_blob;
+};
+
+/*
+ * Create new child key.
+ *
+ * If the specified parent doesn't exist, it is created.
+ *
+ * See `src/internal/keys-impl.c` for parameters used in key creation.
+ *
+ * No auth is set on the key.
+ *
+ * Key is *not* loaded or persisted.
+ * However, parent key *will* be persisted, if created.
+ *
+ * Default parameters:
+ *  - parent_handle = 0x81000001 (set to 0 to use default)
+ *  - hierarchy = TPM2_RH_OWNER (set to 0 to use default)
+ *  - hierarchy_password = empty auth
+ *  - hierarchy_password_length = 0 (set to 0 to use default password)
+ */
+TSS2_RC
+xtpm_gen_key(TSS2_TCTI_CONTEXT *tcti_ctx,
+             TPM2_HANDLE parent_handle,
+             TPMI_RH_HIERARCHY hierarchy,
+             const char *hierarchy_password,
+             size_t hierarchy_password_length,
+             struct xtpm_key *out);
+
+/*
+ * Load the `xtpm_key` into the TPM, so it's usable for signing.
+ *
+ * The handle of the loaded key is returned in `handle_out`.
+ */
+TSS2_RC
+xtpm_load_key(TSS2_TCTI_CONTEXT *tcti_ctx,
+              const struct xtpm_key *key,
+              TPM2_HANDLE *handle_out);
+
+/*
+ * Flush a memory-resident key (at `handle`) from the TPM.
+ */
+TSS2_RC
+xtpm_flush_key(TSS2_TCTI_CONTEXT *tcti_ctx,
+               TPM2_HANDLE handle);
+
+/*
+ * Write key to PEM file.
+ */
+TSS2_RC
+xtpm_write_key(const struct xtpm_key *key,
+               const char *filename);
+
+/*
+ * Retrieve the public key from a `xtpm_key` in x9.62 uncompressed format
+ *
+ * The key is written to `buf` (and always has length `XTPM_PUB_KEY_SIZE` bytes).
+ */
+TSS2_RC
+xtpm_get_public_key(const struct xtpm_key *key,
+                    uint8_t *buf);
+
+/*
+ * Generate signature over `digest` using `key`.
+ *
+ * The signature is returned in `signature_out`.
+ *
+ * Note that this takes a *digest*,
+ * so a message to be signed must first be hashed.
+ */
+TSS2_RC
+xtpm_sign(TSS2_TCTI_CONTEXT *tcti_ctx,
+          const struct xtpm_key *key,
+          const TPM2B_DIGEST *digest,
+          TPMT_SIGNATURE *signature_out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/src/internal/asn1.c
+++ b/src/internal/asn1.c
@@ -1,0 +1,147 @@
+/******************************************************************************
+ *
+ * Copyright 2020 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include "asn1.h"
+
+#include "marshal.h"
+
+#include <tss2/tss2_tpm2_types.h>
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+/**
+    TPM_Loadable_Key ::= SEQUENCE {
+    type            OBJECT IDENTIFIER,
+    emptyAuth       [0] EXPLICIT BOOLEAN OPTIONAL,
+    parent          INTEGER,
+    pubkey          OCTET STRING,
+    privkey         OCTET STRING
+    }
+ */
+
+const uint8_t ASN1_PREAMBLE[] = {
+    0x30, 0x81,                                         // type = sequence, first octet of length indicating "long form" of total length
+    00,                                                 // total length, TO BE FILLED IN
+    0x06, 0x06, 0x67, 0x81, 0x05, 0x0A, 0x01, 0x03,     // - object id - type = 06, length = 06, value = 2.23.133.10.1.3
+    0xA0, 0x03, 0x01, 0x01, 0x01,                       // - empth auth - type = constructed, length = 3, type = boolean, length = 1, value = true
+};
+
+const unsigned char ASN1_INTEGER_TYPE = 0x02;
+const unsigned char ASN1_OCTET_STRING_TYPE = 0x04;
+
+const size_t LENGTH_LOC = 2;
+
+const unsigned char ASN1_LONG_FORM_LENGTH_PREFIX = 0x81;
+
+typedef void (*marshal_func_type)(const void*, uint8_t**);
+
+static
+void
+build_asn1_octet_string(uint8_t **ptr, const void* val, marshal_func_type marshal);
+
+static
+void
+build_asn1_integer(uint8_t **ptr, uint32_t val);
+
+void
+build_asn1_from_key(const struct xtpm_key *key,
+                    uint8_t *buf,
+                    size_t *length)
+{
+    uint8_t *ptr = buf;
+
+    // Preamble
+    memcpy(buf, ASN1_PREAMBLE, sizeof(ASN1_PREAMBLE));
+    ptr += sizeof(ASN1_PREAMBLE);
+
+    // Parent handle
+    build_asn1_integer(&ptr, key->parent_handle);
+
+    // Public key
+    build_asn1_octet_string(&ptr,
+                            &key->public_key,
+                            (marshal_func_type)&marshal_tpm2b_public);
+
+    // Private key
+    build_asn1_octet_string(&ptr,
+                            &key->private_key_blob,
+                            (marshal_func_type)&marshal_tpm2b_private);
+
+    // Save total size to length field of SEQUENCE at beginning of structure.
+    //  (subtract 3 bytes for the type/length fields of the SEQUENCE header itself).
+    *length = ptr - buf;
+    buf[LENGTH_LOC] = *length - 3;
+
+    // Just to make sure this constant is still defined correctly.
+    assert(ASN1_LOADABLE_KEY_MIN_BUF >= *length);
+}
+
+void
+build_asn1_octet_string(uint8_t **ptr, const void* val, marshal_func_type marshal)
+{
+    **ptr = ASN1_OCTET_STRING_TYPE;
+    ++(*ptr);
+
+    uint8_t *size_ptr = *ptr;
+    ++(*ptr);  // Assuming size is < 127B
+
+    marshal(val, ptr);
+
+    size_t marshalled_size = *ptr - (size_ptr + 1);
+    if (marshalled_size < 127) {
+        *size_ptr = marshalled_size;
+    } else {
+        // Marshalled value was larger than expected
+        // so have to use "long-format" length.
+        // (NOTE: we're still assuming the length is <256,
+        //  which TPM2B_[Public, Private] always are).
+        *ptr = size_ptr;
+
+        **ptr = ASN1_LONG_FORM_LENGTH_PREFIX;
+        ++(*ptr);
+
+        **ptr = marshalled_size;
+        ++(*ptr);
+
+        marshal(val, ptr);
+    }
+}
+
+void
+build_asn1_integer(uint8_t **ptr, uint32_t val)
+{
+    **ptr = ASN1_INTEGER_TYPE;
+    ++(*ptr);
+
+    size_t size = sizeof(uint32_t);
+
+    // If msb is set, pad with a zero
+    if (val & 0x80000000) {
+        **ptr = size + 1;
+        ++(*ptr);
+        **ptr = 0;
+        ++(*ptr);
+    } else {
+        **ptr = size;
+        ++(*ptr);
+    }
+
+    marshal_uint32(val, ptr);
+}

--- a/src/internal/asn1.h
+++ b/src/internal/asn1.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright 2017-2020 Xaptum, Inc.
+ * Copyright 2020 Xaptum, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,11 +16,35 @@
  *
  *****************************************************************************/
 
-#ifndef XAPTUM_TPM_H
-#define XAPTUM_TPM_H
+#ifndef XAPTUM_TPM_INTERNAL_ASN1_H
+#define XAPTUM_TPM_INTERNAL_ASN1_H
 #pragma once
 
 #include <xaptum-tpm/keys.h>
-#include <xaptum-tpm/nvram.h>
+
+/*
+ * A buffer of this size is sufficient to hold a Tpm_Loadable_Key ASN.1 structure.
+ */
+#define ASN1_LOADABLE_KEY_MIN_BUF 2240
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Create a TPM_Loadable_Key ASN.1 structure for `key`.
+ *
+ * The structure is written to `buf`,
+ *  and the total size of the structure is returned in `length`.
+ */
+void
+build_asn1_from_key(const struct xtpm_key *key,
+                    uint8_t *buf,
+                    size_t *length);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
+

--- a/src/internal/keys-impl.c
+++ b/src/internal/keys-impl.c
@@ -1,0 +1,299 @@
+/******************************************************************************
+ *
+ * Copyright 2020 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include "keys-impl.h"
+
+#include <string.h>
+
+
+TSS2_RC
+check_parent(TSS2_SYS_CONTEXT *sapi_ctx,
+             TPM2_HANDLE parent_handle)
+{
+    TPM2B_PUBLIC outPublic = {};
+    TPM2B_NAME name = {};
+    TPM2B_NAME qualifiedName = {};
+
+    TSS2_RC ret = Tss2_Sys_ReadPublic(sapi_ctx,
+                                      parent_handle,
+                                      NULL,
+                                      &outPublic,
+                                      &name,
+                                      &qualifiedName,
+                                      NULL);
+
+    if (TSS2_RC_SUCCESS != ret)
+        return ret;
+
+    if (!(outPublic.publicArea.objectAttributes & TPMA_OBJECT_RESTRICTED) ||
+        !(outPublic.publicArea.objectAttributes & TPMA_OBJECT_DECRYPT))
+        return TSS2_SYS_RC_NO_DECRYPT_PARAM;
+
+    return ret;
+}
+
+TSS2_RC
+create_primary(TSS2_SYS_CONTEXT *sapi_ctx,
+               TPMI_RH_HIERARCHY hierarchy,
+               TPM2_HANDLE primary_handle,
+               const char *hierarchy_password,
+               size_t hierarchy_password_length)
+{
+    TSS2L_SYS_AUTH_COMMAND sessionsData = {};
+    sessionsData.auths[0].sessionHandle = TPM2_RS_PW;
+    sessionsData.count = 1;
+
+    if (0 != hierarchy_password_length) {
+        if (hierarchy_password_length > sizeof(sessionsData.auths[0].hmac.buffer))
+            return TSS2_BASE_RC_INSUFFICIENT_BUFFER;
+        sessionsData.auths[0].hmac.size = hierarchy_password_length;
+        memcpy(sessionsData.auths[0].hmac.buffer, hierarchy_password, hierarchy_password_length);
+    }
+
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut = {.count = 1};
+
+    // Nb. no auth set for key
+    TPM2B_SENSITIVE_CREATE inSensitive = {};
+
+    TPM2B_PUBLIC in_public = {
+        .publicArea = {
+            .type = TPM2_ALG_ECC,
+            .nameAlg = TPM2_ALG_SHA256,
+            .objectAttributes = (TPMA_OBJECT_USERWITHAUTH |
+                                 TPMA_OBJECT_RESTRICTED |
+                                 TPMA_OBJECT_DECRYPT |
+                                 TPMA_OBJECT_FIXEDTPM |
+                                 TPMA_OBJECT_FIXEDPARENT |
+                                 TPMA_OBJECT_SENSITIVEDATAORIGIN),
+            .authPolicy = {},
+            .parameters.eccDetail = {
+                 .symmetric = {
+                     .algorithm = TPM2_ALG_AES,
+                     .keyBits.aes = 128,
+                     .mode.sym = TPM2_ALG_CFB,
+                  },
+                 .scheme = {
+                    .scheme = TPM2_ALG_NULL,
+                    .details = {}
+                 },
+                 .curveID = TPM2_ECC_NIST_P256,
+                 .kdf = {
+                    .scheme = TPM2_ALG_NULL,
+                    .details = {}
+                 },
+             },
+            .unique.ecc = {}
+         }
+    };
+
+    TPM2B_DATA outsideInfo = {};
+    TPML_PCR_SELECTION creationPCR = {};
+    TPM2B_CREATION_DATA creationData = {};
+    TPM2B_DIGEST creationHash = {};
+    TPMT_TK_CREATION creationTicket = {};
+    TPM2B_NAME name = {};
+
+    TPM2B_PUBLIC public_key = {};
+
+    TPM2_HANDLE tmp_primary_handle;
+
+    TSS2_RC ret = Tss2_Sys_CreatePrimary(sapi_ctx,
+                                         hierarchy,
+                                         &sessionsData,
+                                         &inSensitive,
+                                         &in_public,
+                                         &outsideInfo,
+                                         &creationPCR,
+                                         &tmp_primary_handle,
+                                         &public_key,
+                                         &creationData,
+                                         &creationHash,
+                                         &creationTicket,
+                                         &name,
+                                         &sessionsDataOut);
+
+    if (TSS2_RC_SUCCESS != ret)
+        return ret;
+
+    // Persist primary key
+    ret = evict_control(sapi_ctx,
+                        hierarchy,
+                        tmp_primary_handle,
+                        primary_handle,
+                        hierarchy_password,
+                        hierarchy_password_length);
+
+    if (TSS2_RC_SUCCESS != ret)
+        return ret;
+
+    ret = Tss2_Sys_FlushContext(sapi_ctx,
+                                tmp_primary_handle);
+
+    return ret;
+}
+
+TSS2_RC
+create_child(TSS2_SYS_CONTEXT *sapi_ctx,
+             TPM2_HANDLE parent_handle,
+             TPM2B_PUBLIC *public_key_out,
+             TPM2B_PRIVATE *private_key_blob_out)
+{
+    TSS2L_SYS_AUTH_COMMAND sessionsData = {};
+    sessionsData.auths[0].sessionHandle = TPM2_RS_PW;
+    sessionsData.count = 1;
+
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut = {.count = 1};
+
+    // Nb. No auth set on key
+    TPM2B_SENSITIVE_CREATE inSensitive = {};
+
+    TPM2B_PUBLIC in_public = {
+        .publicArea = {
+            .type = TPM2_ALG_ECC,
+            .nameAlg = TPM2_ALG_SHA256,
+            .objectAttributes = (TPMA_OBJECT_USERWITHAUTH |
+                                 TPMA_OBJECT_SIGN_ENCRYPT |
+                                 TPMA_OBJECT_FIXEDTPM |
+                                 TPMA_OBJECT_FIXEDPARENT |
+                                 TPMA_OBJECT_SENSITIVEDATAORIGIN),
+            .authPolicy = {},
+            .parameters.eccDetail = {
+                 .symmetric = {
+                     .algorithm = TPM2_ALG_NULL,
+                  },
+                 .scheme = {
+                    .scheme = TPM2_ALG_NULL,
+                    .details = {}
+                 },
+                 .curveID = TPM2_ECC_NIST_P256,
+                 .kdf = {
+                    .scheme = TPM2_ALG_NULL,
+                    .details = {}
+                 },
+             },
+            .unique.ecc = {}
+         }
+    };
+
+    TPM2B_DATA outsideInfo = {};
+
+    TPML_PCR_SELECTION creationPCR = {};
+
+    TPM2B_CREATION_DATA creationData = {};
+    TPM2B_DIGEST creationHash = {};
+    TPMT_TK_CREATION creationTicket = {};
+
+    return Tss2_Sys_Create(sapi_ctx,
+                           parent_handle,
+                           &sessionsData,
+                           &inSensitive,
+                           &in_public,
+                           &outsideInfo,
+                           &creationPCR,
+                           private_key_blob_out,
+                           public_key_out,
+                           &creationData,
+                           &creationHash,
+                           &creationTicket,
+                           &sessionsDataOut);
+}
+
+TSS2_RC
+load_key(TSS2_SYS_CONTEXT *sapi_ctx,
+         TPM2_HANDLE parent_handle,
+         const TPM2B_PUBLIC *public_key,
+         const TPM2B_PRIVATE *private_key_blob,
+         TPM2_HANDLE *handle_out)
+{
+    TSS2L_SYS_AUTH_COMMAND sessionsData = {};
+    sessionsData.auths[0].sessionHandle = TPM2_RS_PW;
+    sessionsData.count = 1;
+
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut = {.count = 1};
+
+    TPM2B_NAME name = {};
+
+    return Tss2_Sys_Load(sapi_ctx,
+                         parent_handle,
+                         &sessionsData,
+                         private_key_blob,
+                         public_key,
+                         handle_out,
+                         &name,
+                         &sessionsDataOut);
+}
+
+TSS2_RC
+evict_control(TSS2_SYS_CONTEXT *sapi_ctx,
+              TPMI_RH_HIERARCHY hierarchy,
+              TPM2_HANDLE current_handle,
+              TPM2_HANDLE persistent_handle,
+              const char *hierarchy_password,
+              size_t hierarchy_password_length)
+{
+    TSS2L_SYS_AUTH_COMMAND sessionsData = {};
+    sessionsData.auths[0].sessionHandle = TPM2_RS_PW;
+    sessionsData.count = 1;
+    if (0 != hierarchy_password_length) {
+        if (hierarchy_password_length > sizeof(sessionsData.auths[0].hmac.buffer))
+            return TSS2_BASE_RC_INSUFFICIENT_BUFFER;
+        sessionsData.auths[0].hmac.size = hierarchy_password_length;
+        memcpy(sessionsData.auths[0].hmac.buffer, hierarchy_password, hierarchy_password_length);
+    }
+
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut = {.count = 1};
+
+    return Tss2_Sys_EvictControl(sapi_ctx,
+                                 hierarchy,
+                                 current_handle,
+                                 &sessionsData,
+                                 persistent_handle,
+                                 &sessionsDataOut);
+}
+
+TSS2_RC
+sign(TSS2_SYS_CONTEXT *sapi_ctx,
+     TPM2_HANDLE key_handle,
+     const TPM2B_DIGEST *digest,
+     TPMT_SIGNATURE *signature_out)
+{
+    TSS2L_SYS_AUTH_COMMAND sessionsData = {};
+    sessionsData.auths[0].sessionHandle = TPM2_RS_PW;
+    sessionsData.count = 1;
+
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut = {.count = 1};
+
+    TPMT_SIG_SCHEME inScheme = {};
+    inScheme.scheme = TPM2_ALG_ECDSA;
+	inScheme.details.ecdsa.hashAlg = TPM2_ALG_SHA256;
+
+    // Hash was *not* generated by TPM,
+    // so tell TPM not to check it (i.e. pass a "NULL ticket").
+    TPMT_TK_HASHCHECK validation = {};
+	validation.tag = TPM2_ST_HASHCHECK;
+	validation.hierarchy = TPM2_RH_NULL;
+
+    return Tss2_Sys_Sign(sapi_ctx,
+                         key_handle,
+                         &sessionsData,
+                         digest,
+                         &inScheme,
+                         &validation,
+                         signature_out,
+                         &sessionsDataOut);
+}

--- a/src/internal/keys-impl.h
+++ b/src/internal/keys-impl.h
@@ -1,0 +1,113 @@
+/******************************************************************************
+ *
+ * Copyright 2020 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#ifndef XAPTUM_TPM_INTERNAL_KEYSIMPL_H
+#define XAPTUM_TPM_INTERNAL_KEYSIMPL_H
+#pragma once
+
+#include <tss2/tss2_tcti.h>
+#include <tss2/tss2_sys.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Check if `parent_handle` is loaded and is usable as a parent key.
+ *
+ * Returns TSS2_RC_SUCCESS if key is OK,
+ * or other is not.
+ */
+TSS2_RC
+check_parent(TSS2_SYS_CONTEXT *sapi_ctx,
+             TPM2_HANDLE parent_handle);
+
+/*
+ * Create (and persist at `primary_handle`) a new primary key in `hierarchy`.
+ *
+ * New primary key has *no* auth set.
+ *
+ * If a password has been set for `hierarchy`, this must be provided as `hierarchy_password`.
+ */
+TSS2_RC
+create_primary(TSS2_SYS_CONTEXT *sapi_ctx,
+               TPMI_RH_HIERARCHY hierarchy,
+               TPM2_HANDLE primary_handle,
+               const char *hierarchy_password,
+               size_t hierarchy_password_length);
+
+/*
+ * Create a new key under `parent_handle`.
+ *
+ * The public information is returned in `public_key_out`,
+ * and the encrypted private blob is returned in `private_key_blob_out`.
+ *
+ * The new key has *no* auth set.
+ */
+TSS2_RC
+create_child(TSS2_SYS_CONTEXT *sapi_ctx,
+             TPM2_HANDLE parent_handle,
+             TPM2B_PUBLIC *public_key_out,
+             TPM2B_PRIVATE *private_key_blob_out);
+
+/*
+ * Make the given key available for signing.
+ *
+ * The key is specified via `public_key` and `private_key_blob`,
+ * and is assumed to have been created under `parent_handle`.
+ *
+ * The handle where the key is available will be returned in `handle_out`.
+ */
+TSS2_RC
+load_key(TSS2_SYS_CONTEXT *sapi_ctx,
+         TPM2_HANDLE parent_handle,
+         const TPM2B_PUBLIC *public_key,
+         const TPM2B_PRIVATE *private_key_blob,
+         TPM2_HANDLE *handle_out);
+
+/*
+ * Persist the object at `current_handle` to `persistent_handle`.
+ *
+ * If a password has been set for `hierarchy`, this must be provided as `hierarchy_password`.
+ */
+TSS2_RC
+evict_control(TSS2_SYS_CONTEXT *sapi_ctx,
+              TPMI_RH_HIERARCHY hierarchy,
+              TPM2_HANDLE current_handle,
+              TPM2_HANDLE persistent_handle,
+              const char *hierarchy_password,
+              size_t hierarchy_password_length);
+
+/*
+ * Create signature over `digest` using `key_handle`.
+ *
+ * NOTE: This currently assumes this is a ECDSA-with-SHA256 key.
+ *
+ * The key is assumed to have no auth set.
+ */
+TSS2_RC
+sign(TSS2_SYS_CONTEXT *sapi_ctx,
+     TPM2_HANDLE key_handle,
+     const TPM2B_DIGEST *digest,
+     TPMT_SIGNATURE *signature_out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/internal/marshal.c
+++ b/src/internal/marshal.c
@@ -1,0 +1,213 @@
+/******************************************************************************
+ *
+ * Copyright 2017 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include "marshal.h"
+
+#include <string.h>
+
+#define BIT_ZERO 1
+#define BIT_ONE 2
+#define BIT_TWO 4
+#define BIT_THREE 8
+#define BIT_FOUR 16
+#define BIT_FIVE 32
+#define BIT_SIX 64
+#define BIT_SEVEN 128
+
+#include <assert.h>
+
+typedef struct {
+    uint16_t size;
+    uint8_t buffer[TPM2_SHA512_DIGEST_SIZE];
+} TPM2B_SIMPLE;
+
+static
+void marshal_uint16(uint16_t in, uint8_t **out);
+
+static
+void marshal_tpms_ecc_point(const TPMS_ECC_POINT *in, uint8_t **out);
+
+static
+void marshal_tpm2b_simple(const TPM2B_SIMPLE *in, uint8_t **out);
+
+static
+void marshal_tpmi_alg_id(TPM2_ALG_ID in, uint8_t **out);
+
+static
+void  marshal_tpma_object(const TPMA_OBJECT *in, uint8_t **out);
+
+static
+void marshal_tpmt_sym_def_object(const TPMT_SYM_DEF_OBJECT *in, uint8_t **out);
+
+static
+void marshal_tpmt_ecc_scheme(const TPMT_ECC_SCHEME * in, uint8_t **out);
+
+static
+void marshal_tpms_ecc_parms(const TPMS_ECC_PARMS *in, uint8_t **out);
+
+void marshal_uint32(uint32_t in, uint8_t **out)
+{
+    (*out)[0] = (unsigned char)(in >> 24);  /* 3*8 */
+    (*out)[1] = (unsigned char)(in >> 16);  /* 2*8 */
+    (*out)[2] = (unsigned char)(in >> 8);   /* 1*8 */
+    (*out)[3] = (unsigned char)(in);        /* 0*8 */
+
+    *out += sizeof(uint32_t);
+}
+
+void marshal_tpm2b_public(const TPM2B_PUBLIC *in, uint8_t **out)
+{
+    uint8_t *size_ptr = *out;
+    *out += sizeof(uint16_t);
+
+    marshal_tpmi_alg_id(in->publicArea.type, out);
+
+    marshal_tpmi_alg_id(in->publicArea.nameAlg, out);
+
+    marshal_tpma_object(&in->publicArea.objectAttributes, out);
+
+    marshal_tpm2b_simple((TPM2B_SIMPLE*)&in->publicArea.authPolicy, out);
+
+    switch (in->publicArea.type) {
+        case TPM2_ALG_ECC:
+            marshal_tpms_ecc_parms(&in->publicArea.parameters.eccDetail, out);
+            marshal_tpms_ecc_point(&in->publicArea.unique.ecc, out);
+            break;
+    }
+
+    uint16_t size = *out - size_ptr - sizeof(uint16_t);
+    marshal_uint16(size, &size_ptr);
+}
+
+void marshal_tpm2b_private(const TPM2B_PRIVATE *in, uint8_t **out)
+{
+    marshal_tpm2b_simple((TPM2B_SIMPLE*)in, out);
+}
+
+/*
+ * Private functions
+ */
+
+void marshal_uint16(uint16_t in, uint8_t **out)
+{
+    (*out)[0] = (unsigned char)(in >> 8);   /* 1*8 */
+    (*out)[1] = (unsigned char)(in);        /* 0*8 */
+
+    *out += sizeof(uint16_t);
+}
+
+void marshal_tpms_ecc_point(const TPMS_ECC_POINT *in, uint8_t **out)
+{
+    marshal_tpm2b_simple((TPM2B_SIMPLE*)&in->x, out);
+
+    marshal_tpm2b_simple((TPM2B_SIMPLE*)&in->y, out);
+}
+
+void marshal_tpm2b_simple(const TPM2B_SIMPLE *in, uint8_t **out)
+{
+    marshal_uint16(in->size, out);
+    memcpy(*out, in->buffer, in->size);
+    *out += in->size;
+}
+
+void marshal_tpmi_alg_id(TPM2_ALG_ID in, uint8_t **out)
+{
+    marshal_uint16(in, out);
+}
+
+void  marshal_tpma_object(const TPMA_OBJECT *in, uint8_t **out)
+{
+    memset(*out, 0, 4);  // clear all
+
+    // bit zero is reserved
+    if (*in & TPMA_OBJECT_FIXEDTPM)
+        (*out)[3] |= BIT_ONE;
+    if (*in & TPMA_OBJECT_STCLEAR)
+        (*out)[3] |= BIT_TWO;
+    // bit three is reserved
+    if (*in & TPMA_OBJECT_FIXEDPARENT)
+        (*out)[3] |= BIT_FOUR;
+    if (*in & TPMA_OBJECT_SENSITIVEDATAORIGIN)
+        (*out)[3] |= BIT_FIVE;
+    if (*in & TPMA_OBJECT_USERWITHAUTH)
+        (*out)[3] |= BIT_SIX;
+    if (*in & TPMA_OBJECT_ADMINWITHPOLICY)
+        (*out)[3] |= BIT_SEVEN;
+    // bit 8 is reserved
+    // bit 9 is reserved
+    if (*in & TPMA_OBJECT_NODA)
+        (*out)[2] |= BIT_TWO;
+    if (*in & TPMA_OBJECT_ENCRYPTEDDUPLICATION)
+        (*out)[2] |= BIT_THREE;
+    // bit 12 is reserved
+    // bit 13 is reserved
+    // bit 14 is reserved
+    // bit 15 is reserved
+    if (*in & TPMA_OBJECT_RESTRICTED)
+        (*out)[1] |= BIT_ZERO;
+    if (*in & TPMA_OBJECT_DECRYPT)
+        (*out)[1] |= BIT_ONE;
+    if (*in & TPMA_OBJECT_SIGN_ENCRYPT)
+        (*out)[1] |= BIT_TWO;
+    // bits 19-31 are reserved
+
+    *out += 4;
+}
+
+void marshal_tpmt_sym_def_object(const TPMT_SYM_DEF_OBJECT *in, uint8_t **out)
+{
+    switch (in->algorithm) {
+        case TPM2_ALG_NULL:
+            marshal_uint16(TPM2_ALG_NULL, out);
+            break;
+        case TPM2_ALG_AES:
+            marshal_uint16(TPM2_ALG_AES, out);
+            marshal_uint16(in->keyBits.aes, out);
+            marshal_tpmi_alg_id(in->mode.sym, out);
+            break;
+    }
+}
+
+void marshal_tpmt_ecc_scheme(const TPMT_ECC_SCHEME * in, uint8_t **out)
+{
+    marshal_tpmi_alg_id(in->scheme, out);
+
+    switch (in->scheme) {
+        case TPM2_ALG_ECDAA:
+            marshal_tpmi_alg_id(in->details.ecdaa.hashAlg, out);
+            marshal_uint16(in->details.ecdaa.count, out);
+            break;
+        case TPM2_ALG_ECDSA:
+            marshal_tpmi_alg_id(in->details.ecdsa.hashAlg, out);
+            break;
+    }
+}
+
+void marshal_tpms_ecc_parms(const TPMS_ECC_PARMS *in, uint8_t **out)
+{
+    marshal_tpmt_sym_def_object(&in->symmetric, out);
+
+    marshal_tpmt_ecc_scheme(&in->scheme, out);
+
+    marshal_tpmi_alg_id(in->curveID, out);
+
+    marshal_tpmi_alg_id(in->kdf.scheme, out);
+
+    assert(in->kdf.scheme == TPM2_ALG_NULL);
+}
+

--- a/src/internal/marshal.h
+++ b/src/internal/marshal.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright 2017-2020 Xaptum, Inc.
+ * Copyright 2020 Xaptum, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,11 +16,31 @@
  *
  *****************************************************************************/
 
-#ifndef XAPTUM_TPM_H
-#define XAPTUM_TPM_H
+/*
+ * TSS serialization, adapted from `tss2/src/internal/marshal`.
+ */
+
+#ifndef XAPTUM_TPM_INTERNAL_MARSHAL_H
+#define XAPTUM_TPM_INTERNAL_MARSHAL_H
 #pragma once
 
-#include <xaptum-tpm/keys.h>
-#include <xaptum-tpm/nvram.h>
+#include <tss2/tss2_tpm2_types.h>
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void marshal_uint32(uint32_t in, uint8_t **out);
+
+void marshal_tpm2b_public(const TPM2B_PUBLIC *in, uint8_t **out);
+
+void marshal_tpm2b_private(const TPM2B_PRIVATE *in, uint8_t **out);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
+

--- a/src/internal/pem.c
+++ b/src/internal/pem.c
@@ -1,0 +1,109 @@
+/******************************************************************************
+ *
+ * Copyright 2020 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include "pem.h"
+
+#include <stdio.h>
+
+const char *PEM_HEADER = "-----BEGIN TSS2 PRIVATE KEY-----";
+const char *PEM_FOOTER = "-----END TSS2 PRIVATE KEY-----";
+const int PEM_LINE_LIMIT = 64;
+
+const char base64_map[] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+                           'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+                           'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+                           'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+                           '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'};
+
+#define CHUNK0(byte_0) ( byte_0 >> 2 )
+#define CHUNK1(byte_0, byte_1) ( ((0x3 & byte_0) << 4) + (byte_1 >> 4) )
+#define CHUNK2(byte_1, byte_2) ( ((0xF & byte_1) << 2) + (byte_2 >> 6) )
+#define CHUNK3(byte_2) ( 0x3F & byte_2 )
+
+#define checked_print(file_ptr, ...) \
+    do \
+    { \
+        if (fprintf(file_ptr, __VA_ARGS__) < 0) { \
+            ret = -1; \
+            goto finish; \
+        } \
+    } while(0)
+
+int
+write_pem(const char *filename,
+          const uint8_t *buffer,
+          size_t buffer_length)
+{
+    FILE *file_ptr = fopen(filename, "w");
+    if (NULL == file_ptr)
+        return -1;
+
+    int ret = 0;
+
+    checked_print(file_ptr, "%s\n", PEM_HEADER);
+
+    size_t pos = 0;
+    int line_size = 0;
+    for (; pos <= buffer_length - 3; pos += 3) {
+        unsigned char byte_0=buffer[pos];
+        unsigned char byte_1=buffer[pos+1];
+        unsigned char byte_2=buffer[pos+2];
+
+        char out[] = {base64_map[ CHUNK0(byte_0) ],
+                      base64_map[ CHUNK1(byte_0, byte_1) ],
+                      base64_map[ CHUNK2(byte_1, byte_2) ],
+                      base64_map[ CHUNK3(byte_2) ]};
+
+        for (size_t i=0; i<sizeof(out); ++i) {
+            if (PEM_LINE_LIMIT == line_size) {
+                checked_print(file_ptr, "\n%c", out[i]);
+                line_size = 1;
+            } else {
+                checked_print(file_ptr, "%c", out[i]);
+                ++line_size;
+            }
+        }
+    }
+
+    int leftover_bytes = buffer_length % 3 ;
+    if (2 == leftover_bytes) {
+        unsigned char byte_0=buffer[pos];
+        unsigned char byte_1=buffer[pos+1];
+
+        checked_print(file_ptr, "%c", base64_map[ CHUNK0(byte_0) ]);
+        checked_print(file_ptr, "%c", base64_map[ CHUNK1(byte_0, byte_1) ]);
+        checked_print(file_ptr, "%c", base64_map[ CHUNK2(byte_1, 0) ]);
+
+        checked_print(file_ptr, "%c", '=');
+    } else if (1 == leftover_bytes) {
+        unsigned char byte_0=buffer[pos];
+
+        checked_print(file_ptr, "%c", base64_map[ CHUNK0(byte_0) ]);
+        checked_print(file_ptr, "%c", base64_map[ CHUNK1(byte_0, 0) ]);
+
+        checked_print(file_ptr, "%c", '=');
+        checked_print(file_ptr, "%c", '=');
+    }
+
+    checked_print(file_ptr, "\n%s\n", PEM_FOOTER);
+
+finish:
+    fclose(file_ptr);
+
+    return ret;
+}

--- a/src/internal/pem.h
+++ b/src/internal/pem.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright 2017-2020 Xaptum, Inc.
+ * Copyright 2020 Xaptum, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,11 +16,30 @@
  *
  *****************************************************************************/
 
-#ifndef XAPTUM_TPM_H
-#define XAPTUM_TPM_H
+#ifndef XAPTUM_TPM_INTERNAL_PEM_H
+#define XAPTUM_TPM_INTERNAL_PEM_H
 #pragma once
 
-#include <xaptum-tpm/keys.h>
-#include <xaptum-tpm/nvram.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Save the `buffer` of `buffer_length` bytes to a PEM-encoded file.
+ *
+ * Returns 0 on success,
+ * <0 otherwise.
+ */
+int
+write_pem(const char *filename,
+          const uint8_t *buffer,
+          size_t buffer_length);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/internal/sapi.c
+++ b/src/internal/sapi.c
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright 2017-2020 Xaptum, Inc.
+ * Copyright 2020 Xaptum, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,11 +16,30 @@
  *
  *****************************************************************************/
 
-#ifndef XAPTUM_TPM_H
-#define XAPTUM_TPM_H
-#pragma once
+#include "sapi.h"
 
-#include <xaptum-tpm/keys.h>
-#include <xaptum-tpm/nvram.h>
+#include <stdlib.h>
 
-#endif
+TSS2_RC
+init_sapi(TSS2_SYS_CONTEXT **sapi_ctx, TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    size_t sapi_ctx_size = Tss2_Sys_GetContextSize(0);
+
+    *sapi_ctx = malloc(sapi_ctx_size);
+    if (NULL == *sapi_ctx) {
+        return TSS2_TCTI_RC_BAD_REFERENCE;
+    }
+
+    TSS2_ABI_VERSION abi_version = TSS2_ABI_VERSION_CURRENT;
+    TSS2_RC init_ret = Tss2_Sys_Initialize(*sapi_ctx,
+                                           sapi_ctx_size,
+                                           tcti_ctx,
+                                           &abi_version);
+
+    if (TSS2_RC_SUCCESS != init_ret) {
+        free(*sapi_ctx);
+        *sapi_ctx = NULL;
+    }
+
+    return init_ret;
+}

--- a/src/internal/sapi.h
+++ b/src/internal/sapi.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright 2017-2020 Xaptum, Inc.
+ * Copyright 2020 Xaptum, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,11 +16,31 @@
  *
  *****************************************************************************/
 
-#ifndef XAPTUM_TPM_H
-#define XAPTUM_TPM_H
+#ifndef XAPTUM_TPM_INTERNAL_SAPI_H
+#define XAPTUM_TPM_INTERNAL_SAPI_H
 #pragma once
 
-#include <xaptum-tpm/keys.h>
-#include <xaptum-tpm/nvram.h>
+#include <tss2/tss2_tcti.h>
+#include <tss2/tss2_sys.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Initialize a SYS_CONTEXT into memory returned in `sapi_ctx`.
+ *
+ * This allocates memory, pointed to by `*sapi_ctx`,
+ * so it must be `free`'d after use.
+ *
+ * Returns `TSS2_RC_SUCCESS` on success,
+ * other otherwise (in which case `*sapi_ctx == NULL`).
+ */
+TSS2_RC
+init_sapi(TSS2_SYS_CONTEXT **sapi_ctx, TSS2_TCTI_CONTEXT *tcti_ctx);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/keys.c
+++ b/src/keys.c
@@ -1,0 +1,214 @@
+/******************************************************************************
+ *
+ * Copyright 2020 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include "internal/asn1.h"
+#include "internal/keys-impl.h"
+#include "internal/pem.h"
+#include "internal/sapi.h"
+
+#include <xaptum-tpm/keys.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#define DEFAULT_PARENT_KEY 0x81000001
+#define DEFAULT_HIERARCHY TPM2_RH_OWNER
+
+TSS2_RC
+xtpm_gen_key(TSS2_TCTI_CONTEXT *tcti_ctx,
+             TPM2_HANDLE parent_handle_in,
+             TPMI_RH_HIERARCHY hierarchy_in,
+             const char *hierarchy_password,
+             size_t hierarchy_password_length,
+             struct xtpm_key *out)
+{
+    TSS2_RC ret;
+
+    TPMI_RH_HIERARCHY hierarchy;
+    if (0 == hierarchy_in) {
+        hierarchy = DEFAULT_HIERARCHY;
+    } else {
+        hierarchy = hierarchy_in;
+    }
+
+    TPM2_HANDLE parent_handle;
+    if (0 == parent_handle_in) {
+        parent_handle = DEFAULT_PARENT_KEY;
+    } else {
+        parent_handle = parent_handle_in;
+    }
+
+    TSS2_SYS_CONTEXT *sapi_ctx = NULL;
+    ret = init_sapi(&sapi_ctx, tcti_ctx);
+    if (TSS2_RC_SUCCESS != ret)
+        goto finish;
+
+    if (TSS2_RC_SUCCESS != check_parent(sapi_ctx, parent_handle)) {
+        ret = create_primary(sapi_ctx,
+                             hierarchy,
+                             parent_handle,
+                             hierarchy_password,
+                             hierarchy_password_length);
+        if (TSS2_RC_SUCCESS != ret)
+            goto finish;
+    }
+
+    out->parent_handle = parent_handle;
+    ret = create_child(sapi_ctx,
+                       parent_handle,
+                       &out->public_key,
+                       &out->private_key_blob);
+    if (TSS2_RC_SUCCESS != ret)
+        goto finish;
+
+finish:
+    if (sapi_ctx) {
+        Tss2_Sys_Finalize(sapi_ctx);
+        free(sapi_ctx);
+    }
+
+    return ret;
+}
+
+TSS2_RC
+xtpm_load_key(TSS2_TCTI_CONTEXT *tcti_ctx,
+              const struct xtpm_key *key,
+              TPM2_HANDLE *handle_out)
+{
+    TSS2_RC ret;
+
+    TSS2_SYS_CONTEXT *sapi_ctx = NULL;
+    ret = init_sapi(&sapi_ctx, tcti_ctx);
+    if (TSS2_RC_SUCCESS != ret)
+        goto finish;
+
+    ret = load_key(sapi_ctx,
+                   key->parent_handle,
+                   &key->public_key,
+                   &key->private_key_blob,
+                   handle_out);
+
+finish:
+    if (sapi_ctx) {
+        Tss2_Sys_Finalize(sapi_ctx);
+        free(sapi_ctx);
+    }
+
+    return ret;
+}
+
+TSS2_RC
+xtpm_flush_key(TSS2_TCTI_CONTEXT *tcti_ctx,
+               TPM2_HANDLE handle)
+{
+    TSS2_RC ret;
+
+    TSS2_SYS_CONTEXT *sapi_ctx = NULL;
+    ret = init_sapi(&sapi_ctx, tcti_ctx);
+    if (TSS2_RC_SUCCESS != ret)
+        goto finish;
+
+    ret = Tss2_Sys_FlushContext(sapi_ctx,
+                                handle);
+
+finish:
+    if (sapi_ctx) {
+        Tss2_Sys_Finalize(sapi_ctx);
+        free(sapi_ctx);
+    }
+
+    return ret;
+}
+
+TSS2_RC
+xtpm_write_key(const struct xtpm_key *key,
+               const char *filename)
+{
+    uint8_t buf[ASN1_LOADABLE_KEY_MIN_BUF];
+
+    size_t total_size = 0;
+
+    build_asn1_from_key(key, buf, &total_size);
+
+    int write_ret = write_pem(filename, buf, total_size);
+    if (0 != write_ret)
+        return TSS2_BASE_RC_IO_ERROR;
+
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+xtpm_get_public_key(const struct xtpm_key *key,
+                    uint8_t *buf)
+{
+    buf[0] = 0x04;  // indicates uncompressed format
+
+    if (32 != key->public_key.publicArea.unique.ecc.x.size)
+        return TSS2_BASE_RC_BAD_VALUE;
+
+    memcpy(buf + 1, key->public_key.publicArea.unique.ecc.x.buffer, 32);
+
+    if (32 != key->public_key.publicArea.unique.ecc.y.size)
+        return TSS2_BASE_RC_BAD_VALUE;
+
+    memcpy(buf + 1 + 32, key->public_key.publicArea.unique.ecc.y.buffer, 32);
+
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+xtpm_sign(TSS2_TCTI_CONTEXT *tcti_ctx,
+          const struct xtpm_key *key,
+          const TPM2B_DIGEST *digest,
+          TPMT_SIGNATURE *signature_out)
+{
+    TSS2_RC ret;
+
+    TSS2_SYS_CONTEXT *sapi_ctx = NULL;
+    ret = init_sapi(&sapi_ctx, tcti_ctx);
+    if (TSS2_RC_SUCCESS != ret)
+        goto finish;
+
+    TPM2_HANDLE loaded_key;
+    ret = load_key(sapi_ctx,
+                   key->parent_handle,
+                   &key->public_key,
+                   &key->private_key_blob,
+                   &loaded_key);
+
+    if (TSS2_RC_SUCCESS != ret)
+        goto finish;
+
+    ret = sign(sapi_ctx,
+               loaded_key,
+               digest,
+               signature_out);
+
+    TSS2_RC flush_ret = Tss2_Sys_FlushContext(sapi_ctx,
+                                              loaded_key);
+    if (TSS2_RC_SUCCESS != ret)
+        ret = flush_ret;
+
+finish:
+    if (sapi_ctx) {
+        Tss2_Sys_Finalize(sapi_ctx);
+        free(sapi_ctx);
+    }
+
+    return ret;
+}

--- a/test/keys-test.c
+++ b/test/keys-test.c
@@ -1,0 +1,282 @@
+/******************************************************************************
+ *
+ * Copyright 2020 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include <xaptum-tpm/keys.h>
+
+#include "test-utils.h"
+
+#include <stdbool.h>
+
+void default_parent_test(TSS2_TCTI_CONTEXT *tcti_ctx);
+
+void get_pub_test(TSS2_TCTI_CONTEXT *tcti_ctx);
+
+void write_key_test(TSS2_TCTI_CONTEXT *tcti_ctx);
+
+void authd_parent_test(TSS2_TCTI_CONTEXT *tcti_ctx);
+
+void load_created_test(TSS2_TCTI_CONTEXT *tcti_ctx);
+
+void flush_test(TSS2_TCTI_CONTEXT *tcti_ctx);
+
+void sign_test(TSS2_TCTI_CONTEXT *tcti_ctx);
+
+void multiple_gens_test(TSS2_TCTI_CONTEXT *tcti_ctx);
+
+void multiple_gens_diffparent_test(TSS2_TCTI_CONTEXT *tcti_ctx);
+
+void multiple_signs_test(TSS2_TCTI_CONTEXT *tcti_ctx);
+
+int main()
+{
+    TSS2_TCTI_CONTEXT *tcti_ctx = NULL;
+    init_tcti(&tcti_ctx);
+
+    clear(tcti_ctx);
+    default_parent_test(tcti_ctx);
+
+    clear(tcti_ctx);
+    get_pub_test(tcti_ctx);
+
+    clear(tcti_ctx);
+    write_key_test(tcti_ctx);
+
+    clear(tcti_ctx);
+    authd_parent_test(tcti_ctx);
+
+    clear(tcti_ctx);
+    load_created_test(tcti_ctx);
+
+    clear(tcti_ctx);
+    sign_test(tcti_ctx);
+
+    clear(tcti_ctx);
+    flush_test(tcti_ctx);
+
+    clear(tcti_ctx);
+    multiple_gens_test(tcti_ctx);
+
+    clear(tcti_ctx);
+    multiple_gens_diffparent_test(tcti_ctx);
+
+    clear(tcti_ctx);
+    multiple_signs_test(tcti_ctx);
+
+    clear(tcti_ctx);
+    Tss2_Tcti_Finalize(tcti_ctx);
+    free(tcti_ctx);
+}
+
+void default_parent_test(TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    printf("In keys-test::default_parent_test...\n");
+
+    struct xtpm_key out = {};
+
+    TSS2_RC ret = xtpm_gen_key(tcti_ctx, 0, 0, NULL, 0, &out);
+
+    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+
+    printf("ok\n");
+}
+
+void get_pub_test(TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    printf("In keys-test::get_pub_test...\n");
+
+    struct xtpm_key out = {};
+
+    TSS2_RC ret = xtpm_gen_key(tcti_ctx, 0, 0, NULL, 0, &out);
+
+    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+
+    uint8_t pub_key[XTPM_PUB_KEY_SIZE];
+    ret = xtpm_get_public_key(&out, pub_key);
+
+    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+
+    printf("ok\n");
+}
+
+void write_key_test(TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    printf("In keys-test::default_parent_test...\n");
+
+    struct xtpm_key out = {};
+
+    TSS2_RC ret = xtpm_gen_key(tcti_ctx, 0, 0, NULL, 0, &out);
+
+    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+
+    ret = xtpm_write_key(&out, "key.pem");
+
+    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+
+    printf("ok\n");
+}
+
+void authd_parent_test(TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    printf("In keys-test::authd_parent_test...\n");
+
+    struct xtpm_key out = {};
+
+    const char* auth_password = "foo";
+    size_t password_size = strlen(auth_password);
+
+    set_password(tcti_ctx, auth_password);
+
+    TSS2_RC ret = xtpm_gen_key(tcti_ctx, 0, 0, auth_password, password_size, &out);
+
+    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+
+    printf("ok\n");
+}
+
+void load_created_test(TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    printf("In keys-test::load_created_test...\n");
+
+    struct xtpm_key key = {};
+
+    TSS2_RC ret = xtpm_gen_key(tcti_ctx, 0, 0, NULL, 0, &key);
+
+    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+
+    TPM2_HANDLE handle;
+    ret = xtpm_load_key(tcti_ctx, &key, &handle);
+
+    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+
+    printf("ok\n");
+}
+
+void sign_test(TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    printf("In keys-test::sign_test...\n");
+
+    struct xtpm_key key = {};
+
+    TSS2_RC ret = xtpm_gen_key(tcti_ctx, 0, 0, NULL, 0, &key);
+
+    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+
+    // digest = sha-256("foo")
+    TPM2B_DIGEST digest = {.size=32,
+                           .buffer={0xb5, 0xbb, 0x9d, 0x80, 0x14, 0xa0, 0xf9, 0xb1, 0xd6, 0x1e, 0x21, 0xe7, 0x96, 0xd7, 0x8d, 0xcc,
+                                    0xdf, 0x13, 0x52, 0xf2, 0x3c, 0xd3, 0x28, 0x12, 0xf4, 0x85, 0x0b, 0x87, 0x8a, 0xe4, 0x94, 0x4c}};
+    TPMT_SIGNATURE signature;
+    ret = xtpm_sign(tcti_ctx, &key, &digest, &signature);
+
+    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+
+    TEST_ASSERT(signature.sigAlg == TPM2_ALG_ECDSA);
+    TEST_ASSERT(signature.signature.ecdsa.hash == TPM2_ALG_SHA256);
+    TEST_ASSERT(signature.signature.ecdsa.signatureR.size == 32);
+    TEST_ASSERT(signature.signature.ecdsa.signatureS.size == 32);
+
+    printf("ok\n");
+}
+
+void flush_test(TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    printf("In keys-test::flush_test...\n");
+
+    struct xtpm_key key = {};
+
+    TSS2_RC ret = xtpm_gen_key(tcti_ctx, 0, 0, NULL, 0, &key);
+
+    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+
+    TPM2_HANDLE handle;
+    bool hit_failure = false;
+    for (int i=0; i<10; i++) {
+        ret = xtpm_load_key(tcti_ctx, &key, &handle);
+        if (TSS2_RC_SUCCESS != ret) {
+            hit_failure = true;
+            break;
+        }
+    }
+    TEST_ASSERT(hit_failure);
+
+    ret = xtpm_flush_key(tcti_ctx, handle);
+    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+
+    ret = xtpm_load_key(tcti_ctx, &key, &handle);
+    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+
+    printf("ok\n");
+}
+
+void multiple_gens_test(TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    printf("In keys-test::multiple_gens_test...\n");
+
+    for (int i=0; i<10; i++) {
+        struct xtpm_key key = {};
+
+        TSS2_RC ret = xtpm_gen_key(tcti_ctx, 0, 0, NULL, 0, &key);
+
+        TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+    }
+
+    printf("ok\n");
+}
+
+void multiple_gens_diffparent_test(TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    printf("In keys-test::multiple_gens_diffparent_test...\n");
+
+    TPM2_HANDLE parent_handle = 0x81000001;
+    for (int i=0; i<5; i++) {   // can only store a limited-number of parents
+        struct xtpm_key key = {};
+
+        TSS2_RC ret = xtpm_gen_key(tcti_ctx, parent_handle, 0, NULL, 0, &key);
+
+        ++parent_handle;
+
+        TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+    }
+
+    printf("ok\n");
+}
+
+void multiple_signs_test(TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    printf("In keys-test::multiple_signs_test...\n");
+
+    struct xtpm_key key = {};
+
+    TSS2_RC ret = xtpm_gen_key(tcti_ctx, 0, 0, NULL, 0, &key);
+
+    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+
+    // digest = sha-256("foo")
+    TPM2B_DIGEST digest = {.size=32,
+                           .buffer={0xb5, 0xbb, 0x9d, 0x80, 0x14, 0xa0, 0xf9, 0xb1, 0xd6, 0x1e, 0x21, 0xe7, 0x96, 0xd7, 0x8d, 0xcc,
+                                    0xdf, 0x13, 0x52, 0xf2, 0x3c, 0xd3, 0x28, 0x12, 0xf4, 0x85, 0x0b, 0x87, 0x8a, 0xe4, 0x94, 0x4c}};
+
+    TPMT_SIGNATURE signature;
+    for (int i=0; i<10; i++) {
+        ret = xtpm_sign(tcti_ctx, &key, &digest, &signature);
+
+        TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+    }
+
+    printf("ok\n");
+}

--- a/test/test-utils.h
+++ b/test/test-utils.h
@@ -114,6 +114,35 @@ void free_sapi(TSS2_SYS_CONTEXT *sapi_ctx)
 }
 
 static inline
+void set_password(TSS2_TCTI_CONTEXT *tcti_ctx, const char *new_password)
+{
+    TSS2_SYS_CONTEXT *sapi_ctx;
+    init_sapi(tcti_ctx, &sapi_ctx);
+
+    TPMI_RH_HIERARCHY hierarchy = TPM2_RH_OWNER;
+
+    TSS2L_SYS_AUTH_COMMAND sessionsData = {};
+    sessionsData.auths[0].sessionHandle = TPM2_RS_PW;
+    sessionsData.count = 1;
+
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut = {.count = 1};
+
+    size_t new_password_length = strlen(new_password);
+    TPM2B_AUTH newAuth = {.size=new_password_length};
+    memcpy(newAuth.buffer, new_password, new_password_length);
+
+    TSS2_RC ret = Tss2_Sys_HierarchyChangeAuth(sapi_ctx,
+                                               hierarchy,
+                                               &sessionsData,
+                                               &newAuth,
+                                               &sessionsDataOut);
+
+    TEST_ASSERT(TSS2_RC_SUCCESS == ret);
+
+    free(sapi_ctx);
+}
+
+static inline
 void clear(TSS2_TCTI_CONTEXT *tcti_ctx)
 {
     TSS2_SYS_CONTEXT *sapi_ctx;


### PR DESCRIPTION
This PR implements a new `keys` functionality, which includes:
- Child key generation
- Checking if a parent handle is usable (and if not creating a parent at that handle)
- Loading a key into the TPM
- Signing using a key
- Getting the raw public key of a TPM key
- Writing a TPM key as a PEM-encoded file

In the grand tradition of this repo, this functionality is only tested on a few happy paths, and low-level byte-wrangling code has no other tests... However, I have used a key generated (and written) using this code in James Bottomley's OpenSSL engine, to create a self-signed certificate (for some reason, I'm having a hard time getting the tpm2-software engine to use an ECDSA key, at least on my VM. But, this has nothing to do with `xaptum-tpm`)

Passwords are not set on any of the created keys. However, operations that require *hierarchy* authorization (creation of a new primary key, persistence of a key to NVRAM) allow a password to be specified, in case the user has set a password on the OWNER hierarchy (in which all the keys are created, by default).

By default, keys are created in the OWNER hierarchy, and the parent is located at `0x800001`. James Bottomley claims that many TPM manufacturers ship their chips with a parent handle already stored at that index, in  which case we're able to just use that key transparently.

Only ECDSA (secp256r1) keys are created, and there are a couple of places in the code where this is assumed. 

The intended use of this new API, in the `enftun` (and `enftun-keygen`), is:
- Use `xtpm_gen_key` and `xtpm_write_key` in `enftun-keygen` to generate a new key
  - The resulting file can then be given to the OpenSSL code for creating the self-signed certificate
  - If the user has set a password on the OWNER hierarchy, they can specify it here (manually, presumably)
  - This results in a parent key that's persisted to the TPM's NVRAM, and a child key that's output to file as a PEM-encoded encrypted blob
- When running the TLS handshake in `enftun`:
  - Read in the key file
  - Use the OpenSSL library to parse the PEM and ASN.1, in order to get the `parent` field from the key file
    - I didn't include any analogous functionality in this code, because writing an ASN.1 parser is a much larger/hairier task, and in this one usecase we already know we have access to OpenSSL
  - Use the `xtpm_create_parent` function to ensure the parent is available in the TPM
    - If the user has set a password on the OWNER hierarchy, and the parent key is *not* available, then the re-creation of the parent key will fail
    - This code does provide the option that they could specify the password in a config file provided to `enftun`, but that's obviously a dumb idea. So, I don't really know if there's any good way to handle that scenario
    - But, just to be clear, the happy path (the parent *does* exist and is OK), doesn't require a password
  - Pass the key file to the OpenSSL library as usual

I'm working now on updating `xtt` to use this functionality.

I wanted to see what you guys think of the API