### PR TITLE
nvram: Add index for ECDAA_KEY_HANDLE

### DIFF
--- a/include/xaptum-tpm/nvram.h
+++ b/include/xaptum-tpm/nvram.h
@@ -26,6 +26,7 @@
 extern "C" {
 #endif
 
+#define XTPM_ECDAA_KEY_HANDLE       0x81800000
 #define XTPM_GPK_HANDLE             0x1410000
 #define XTPM_CRED_HANDLE            0x1410001
 #define XTPM_CRED_SIG_HANDLE        0x1410002
@@ -34,6 +35,7 @@ extern "C" {
 #define XTPM_SERVER_ID_HANDLE       0x1410008
 #define XTPM_ROOT_XTTCERT_HANDLE    0x1410009
 
+TPM2_HANDLE xtpm_ecdaa_key_handle();
 TPMI_RH_NV_INDEX xtpm_gpk_handle();
 TPMI_RH_NV_INDEX xtpm_cred_handle();
 TPMI_RH_NV_INDEX xtpm_cred_sig_handle();

--- a/src/nvram.c
+++ b/src/nvram.c
@@ -22,6 +22,11 @@
 
 #include <string.h>
 
+TPM2_HANDLE xtpm_ecdaa_key_handle()
+{
+    return XTPM_ECDAA_KEY_HANDLE;
+}
+
 TPMI_RH_NV_INDEX xtpm_gpk_handle()
 {
     return XTPM_GPK_HANDLE;

--- a/test/nvram-test.c
+++ b/test/nvram-test.c
@@ -81,6 +81,8 @@ void constants_test(void)
 {
     printf("In nvram-test::constants_test...\n");
 
+    TEST_ASSERT(XTPM_ECDAA_KEY_HANDLE == xtpm_ecdaa_key_handle());
+
     TEST_ASSERT(XTPM_GPK_HANDLE == xtpm_gpk_handle());
 
     TEST_ASSERT(XTPM_CRED_HANDLE == xtpm_cred_handle());


### PR DESCRIPTION
This index is used in the xtt repo.

It was previously defined in that repo itself, and all the handles in this repo were also *redefined* there, too. So, in the interest of consolidating these definitions, this PR moves this here.